### PR TITLE
Allow waybar buttons to work on default terminal

### DIFF
--- a/dotfiles/waybar/modules.json
+++ b/dotfiles/waybar/modules.json
@@ -100,7 +100,7 @@
         "return-type": "json",       
         "exec": "~/dotfiles/scripts/updates.sh",
         "restart-interval": 60,
-        "on-click": "alacritty --class dotfiles-floating -e ~/dotfiles/scripts/installupdates.sh",
+        "on-click": "$TERM --class dotfiles-floating -e ~/dotfiles/scripts/installupdates.sh",
         "on-click-right": "~/dotfiles/.settings/software.sh"
     },
     
@@ -325,7 +325,7 @@
         "tooltip-format-ethernet": " {ifname}\nIP: {ipaddr}\n up: {bandwidthUpBits} down: {bandwidthDownBits}",
         "tooltip-format-disconnected": "Disconnected",
         "max-length": 50,
-        "on-click": "alacritty --class dotfiles-floating -e nmtui",
+        "on-click": "$TERM --class dotfiles-floating -e nmtui",
         "on-click-right": "~/dotfiles/.settings/networkmanager.sh"
     },
 

--- a/dotfiles/waybar/modules.json
+++ b/dotfiles/waybar/modules.json
@@ -35,7 +35,8 @@
         "on-click": "activate",
         "on-click-middle": "close",
         "ignore-list": [
-           "Alacritty"
+           "Alacritty",
+           "Kitty"
         ],
         "app_ids-mapping": {
             "firefoxdeveloperedition": "firefox-developer-edition"
@@ -100,7 +101,7 @@
         "return-type": "json",       
         "exec": "~/dotfiles/scripts/updates.sh",
         "restart-interval": 60,
-        "on-click": "$TERM --class dotfiles-floating -e ~/dotfiles/scripts/installupdates.sh",
+        "on-click": "$(cat ~/dotfiles/.settings/terminal.sh) --class dotfiles-floating -e ~/dotfiles/scripts/installupdates.sh",
         "on-click-right": "~/dotfiles/.settings/software.sh"
     },
     
@@ -325,7 +326,7 @@
         "tooltip-format-ethernet": " {ifname}\nIP: {ipaddr}\n up: {bandwidthUpBits} down: {bandwidthDownBits}",
         "tooltip-format-disconnected": "Disconnected",
         "max-length": 50,
-        "on-click": "$TERM --class dotfiles-floating -e nmtui",
+        "on-click": "$(cat ~/dotfiles/.settings/terminal.sh) --class dotfiles-floating -e nmtui",
         "on-click-right": "~/dotfiles/.settings/networkmanager.sh"
     },
 

--- a/dotfiles/waybar/modules.json
+++ b/dotfiles/waybar/modules.json
@@ -36,7 +36,7 @@
         "on-click-middle": "close",
         "ignore-list": [
            "Alacritty",
-           "Kitty"
+           "kitty"
         ],
         "app_ids-mapping": {
             "firefoxdeveloperedition": "firefox-developer-edition"


### PR DESCRIPTION
Currently the updates and nmtui buttons on the waybar will not function if the user desires to use a terminal other than Alacritty. This will allow launching using the default terminal (`$TERM`) instead.