### PR TITLE
Add error handling for git clone in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -159,6 +159,13 @@ else
     echo ":: Setup canceled"
     exit 130
 fi
+
+# Check if the clone was successful
+if [ $? -ne 0 ] || [ ! -d ~/Downloads/dotfiles ] ; then
+    echo ":: Error during cloning the repository. Please check error output and your internet connection."
+    exit 1
+fi
+
 echo ":: Download complete."
 
 # Change into dotfiles folder


### PR DESCRIPTION
During initial execution of the setup.sh I've faced some errors for git clone like:
```
error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8)
error: 1409 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```
While it can be solved by various methods like for me just to switch from https to ssh cloning, I've thought it will be nice to have some error checking for git clone procedure.