### PR TITLE
Added Workspace Switching using $mainMod + Tab and $mainMod + SHIFT Tab

### DIFF
--- a/dotfiles/.config/hypr/conf/keybindings/default.conf
+++ b/dotfiles/.config/hypr/conf/keybindings/default.conf
@@ -90,6 +90,9 @@ bind = $mainMod, mouse_down, workspace, e+1 # Open next workspace
 bind = $mainMod, mouse_up, workspace, e-1 # Open previous workspace
 bind = $mainMod CTRL, down, workspace, empty # Open the next empty workspace
 
+bind = $mainMod, Tab, workspace, m+1 # Open next workspace
+bind = $mainMod SHIFT, Tab, workspace, m-1 # Open previous workspace
+
 # Passthrough SUPER KEY to Virtual Machine
 bind = $mainMod, P, submap, passthru # Passthrough SUPER key to virtual machine
 submap = passthru


### PR DESCRIPTION
This makes it so that when you press Win ( or Super ) + Tab it goes to next Workspace. If you press Super + Shift Tab, it goes to previous workspace. Quite a simple bind.