### PR TITLE
Added functionality for mouse swipe by 3 fingers to switch between workspaces. I also added a bind which I will explain in the PR description.

### DIFF
--- a/share/dotfiles/.config/hypr/conf/layouts/default.conf
+++ b/share/dotfiles/.config/hypr/conf/layouts/default.conf
@@ -13,5 +13,18 @@ master {
 }
 
 gestures {
-    workspace_swipe = false
+  workspace_swipe = true
+  workspace_swipe_fingers = 3
+  workspace_swipe_distance = 500
+  workspace_swipe_invert = true
+  workspace_swipe_min_speed_to_force = 30
+  workspace_swipe_cancel_ratio = 0.5
+  workspace_swipe_create_new = true 
+  workspace_swipe_forever = true
+}
+
+binds {
+  workspace_back_and_forth = true
+  allow_workspace_cycles = true
+  pass_mouse_when_bound = false
 }

--- a/share/dotfiles/.config/hypr/conf/layouts/laptop.conf
+++ b/share/dotfiles/.config/hypr/conf/layouts/laptop.conf
@@ -13,5 +13,18 @@ master {
 }
 
 gestures {
-    workspace_swipe = true
+  workspace_swipe = true
+  workspace_swipe_fingers = 3
+  workspace_swipe_distance = 500
+  workspace_swipe_invert = true
+  workspace_swipe_min_speed_to_force = 30
+  workspace_swipe_cancel_ratio = 0.5
+  workspace_swipe_create_new = true 
+  workspace_swipe_forever = true
+}
+
+binds {
+  workspace_back_and_forth = true
+  allow_workspace_cycles = true
+  pass_mouse_when_bound = false
 }


### PR DESCRIPTION
Use $mainMod + 5 to go to 5th workspace. If you then go to 2nd using $mainMod + 2, and use $mainMod + 2 again, it will go to previous workspace. The new binds {} in the default.conf and layout.conf is for this new accessibility feature.