### PR TITLE
Moved AUR helper download to `~/Downloads`

### DIFF
--- a/lib/install/packages/aur.sh
+++ b/lib/install/packages/aur.sh
@@ -10,8 +10,8 @@ _installYay() {
     _installPackagesPacman "base-devel"
     SCRIPT=$(realpath "$0")
     temp_path=$(dirname "$SCRIPT")
-    git clone https://aur.archlinux.org/yay.git ~/yay
-    cd ~/yay
+    git clone https://aur.archlinux.org/yay.git ~/Downloads/yay
+    cd ~/Downloads/yay
     makepkg -si
     cd $temp_path
     echo ":: yay has been installed successfully."
@@ -21,8 +21,8 @@ _installParu() {
     _installPackagesPacman "base-devel"
     SCRIPT=$(realpath "$0")
     temp_path=$(dirname "$SCRIPT")
-    git clone https://aur.archlinux.org/paru.git ~/paru
-    cd ~/paru
+    git clone https://aur.archlinux.org/paru.git ~/Downloads/paru
+    cd ~/Downloads/paru
     makepkg -si
     cd $temp_path
     echo ":: paru has been installed successfully."


### PR DESCRIPTION
This is a simple update attempting to de-clutter the home directory during setup. Currently the setup script creates an AUR helper folder in the home directory. This changes the folder to the `~/Downloads` directory. This also better follows behavior seen in many places through this project.