### PR TITLE
Fixing `_replaceTextInFile` not setting function parameters

### DIFF
--- a/lib/install/includes/library.sh
+++ b/lib/install/includes/library.sh
@@ -352,6 +352,10 @@ _replaceInFile() {
 
 # replaceTextInFile $customtext $targetFile
 _replaceTextInFile() {
+    # Set function parameters
+    customtext="$1"
+    targetFile=$2
+
     echo $customtext > $targetFile
 }
 


### PR DESCRIPTION
When I attempted to use `_replaceTextInFile`, it didn't work because the parameters being referenced are aren't set. This function isn't used anywhere in the repository currently, but the my other pull request to have a configurable wallpaper folder uses it.

Similarly, I had troubles with the function `_replaceInFile`. I expected to be able to set a start and end parameter and only that section would be replaced with the replacement text. But no, it does line-wise replacements. Also it doesn't delete the old line.