### PR TITLE
Wallpaper folder override

### DIFF
--- a/lib/install/dotfiles/init-pywal.sh
+++ b/lib/install/dotfiles/init-pywal.sh
@@ -6,7 +6,7 @@ if [ ! -f ~/.cache/wal/colors-hyprland.conf ]; then
     echo -e "${GREEN}"
     figlet -f smslant "Pywal"
     echo -e "${NONE}"
-    wal -i ~/wallpaper/default.jpg
+    wal -ei "$HOME/$wallpaper_folder/default.jpg"
     echo ":: Pywal and templates activated."
     echo ""
 else

--- a/lib/install/dotfiles/preparation.sh
+++ b/lib/install/dotfiles/preparation.sh
@@ -99,3 +99,8 @@ echo ":: AUR Helper updated with $aur_helper"
 
 # Write dot folder into settings
 echo "$dot_folder" > $ml4w_directory/$version/.config/ml4w/settings/dotfiles-folder.sh
+
+# Write wallpaper_folder into settings
+if [ -f ~/.config/ml4w/settings/wallpaper-folder.sh ] ;then
+    cp ~/.config/ml4w/settings/wallpaper-folder.sh $ml4w_directory/$version/.config/ml4w/settings
+fi

--- a/lib/install/dotfiles/settings.sh
+++ b/lib/install/dotfiles/settings.sh
@@ -239,4 +239,12 @@ if [ -f ~/.config/ml4w/settings/hypridle_suspend_timeout.sh ] ;then
     _replaceLineInFileCheckpoint "$search_str" "$replace_str" "SUSPEND TIMEOUT" "$HOME/.config/hypr/hypridle.conf"
     echo ":: hypridle_suspend_timeout restored"
 fi
+
+# Replace wallpaper_folder
+if [ -f ~/.config/ml4w/settings/wallpaper-folder.sh ] ;then
+    _replaceTextInFile "wallpaper_folder=$wallpaper_folder" "$HOME/.config/ml4w/settings/wallpaper-folder.sh"
+    _replaceLineInFile "folder = ~\/wallpaper" "folder = $wallpaper_folder" "$HOME/.config/waypaper/config.ini"
+    _replaceLineInFile "wallpaper = ~\/wallpaper\/default\.jpg" "wallpaper = $wallpaper_folder\/default.jpg" "$HOME/.config/waypaper/config.ini"
+    echo ":: wallpaper_folder restored"
+fi
 echo

--- a/lib/install/dotfiles/wallpaper.sh
+++ b/lib/install/dotfiles/wallpaper.sh
@@ -2,50 +2,107 @@
 # Install wallpapers
 # ------------------------------------------------------
 
-if [ -d ~/wallpaper/ ]; then
-    echo "~/wallpaper folder already exists."
-else
-    echo -e "${GREEN}"
-    figlet -f smslant "Wallpapers"
-    echo -e "${NONE}"
+wallpaper_folder="wallpaper"
 
-    mkdir ~/wallpaper
-    cp $wallpaper_directory/* ~/wallpaper/
+_define_wallpaper_folder() {
+    echo ":: Please enter the name of the folder to store wallpapers starting from your home directory."
+    echo ":: (e.g., wallpaper or Documents/wallpaper, ...)"
+    wallpaper_folder_tmp=$(gum input --value "$wallpaper_folder" --placeholder "Enter your wallpaper folder name")
+    wallpaper_folder=${wallpaper_folder_tmp//[[:blank:]]/}
+    if [[ $wallpaper_folder == ".ml4w-hyprland" ]] ;then
+        echo ":: The folder .ml4w-hyprland is not allowed."
+        _define_wallpaper_folder
+    elif [ $? -eq 130 ] ;then
+        echo ":: Wallpaper installation canceled."
+        exit 130
+    elif [ ! -z $wallpaper_folder ] ;then
+        _confirm_wallpaper_folder
+    else
+        echo "ERROR: Please define a folder name"
+        _define_wallpaper_folder
+    fi
+}
+
+_confirm_wallpaper_folder() {
+    echo ":: The wallpapers will be stored to ~/$wallpaper_folder"
+    echo
+    if gum confirm "Do you want use this folder?" ;then
+        if [ ! -d ~/$wallpaper_folder ] ;then 
+            mkdir ~/$wallpaper_folder
+        fi
+    elif [ $? -eq 130 ] ;then
+        echo ":: Wallpaper installation canceled."
+        exit 130
+    else
+        _define_wallpaper_folder
+    fi
+}
+
+_find_wallpaper_folder_cache() {
+    wallpaper_cache_path="$ml4w_directory/$version/.config/ml4w/settings/wallpaper-folder.sh"
+    wallpaper_folder_default=$(grep -v "^[[:space:]]*#" $share_directory/dotfiles/.config/ml4w/settings/wallpaper-folder.sh | head -n 1)
+    wallpaper_folder_tmp="$wallpaper_folder_default"
+
+    if [ -f "$wallpaper_cache_path" ] ;then
+        wallpaper_folder_tmp=$(grep -v "^[[:space:]]*#" $wallpaper_cache_path | head -n 1)
+    elif [ -f ~/.config/ml4w/settings/wallpaper-folder.sh ]; then
+        wallpaper_folder_tmp=$(grep -v "^[[:space:]]*#" ~/.config/ml4w/settings/wallpaper-folder.sh | head -n 1)
+    fi
+
+    if [ "$wallpaper_folder_default" != "$wallpaper_folder_tmp" ] ;then
+        wallpaper_folder=$(echo $wallpaper_folder_tmp | cut -d "=" -f 2- | sed "s|\$HOME/||" | sed "s|$HOME/||")
+        echo ":: An existing wallpaper folder has been detected: ~/$wallpaper_folder"
+    fi
+}
+
+_install_wallpapers() {
+    cp $wallpaper_directory/* ~/$wallpaper_folder/
     echo ":: Default wallpapers installed successfully."
     echo
     echo "You can download and install additional wallpapers from https://github.com/mylinuxforwork/wallpaper/"
-    echo ""
+    echo
     if gum confirm "Do you want to download the repository?" ;then
         if [ -d ~/Downloads/wallpaper ] ;then
             rm -rf ~/Downloads/wallpaper
+            echo ":: ~/Downloads/wallpaper deleted"
         fi
         git clone --depth 1 https://github.com/mylinuxforwork/wallpaper.git ~/Downloads/wallpaper
-        rsync -a -I --exclude-from=$install_directory/includes/excludes.txt ~/Downloads/wallpaper/. ~/wallpaper/
+        rsync -a -I --exclude-from=$install_directory/includes/excludes.txt ~/Downloads/wallpaper/. ~/$wallpaper_folder/
         echo "Wallpapers from the repository installed successfully."
-    elif [ $? -eq 130 ]; then
+    elif [ $? -eq 130 ] ;then
         exit 130
     else
         echo ":: Installation of wallpaper repository skipped."
     fi
-fi
-echo
+    echo
+}
 
-# ------------------------------------------------------
-# Copy default wallpaper files to .cache
-# ------------------------------------------------------
+_cache_wallpapers() {
+    # ------------------------------------------------------
+    # Copy default wallpaper files to .cache
+    # ------------------------------------------------------
 
-# Cache file for holding the current wallpaper
-cache_file="$HOME/.config/ml4w/cache/current_wallpaper"
-rasi_file="$HOME/.config/ml4w/cache/current_wallpaper.rasi"
+    # Cache file for holding the current wallpaper
+    cache_file="$HOME/.config/ml4w/cache/current_wallpaper"
+    rasi_file="$HOME/.config/ml4w/cache/current_wallpaper.rasi"
 
-# Create cache file if not exists
-if [ ! -f $cache_file ] ;then
-    touch $cache_file
-    echo "$HOME/wallpaper/default.jpg" > "$cache_file"
-fi
+    # Create cache file if not exists
+    if [ ! -f $cache_file ] ;then
+        touch $cache_file
+        echo "~/$wallpaper_folder/default.jpg" > "$cache_file"
+    fi
 
-# Create rasi file if not exists
-if [ ! -f $rasi_file ] ;then
-    touch $rasi_file
-    echo "* { current-image: url(\"$HOME/wallpaper/default.jpg\", height); }" > "$rasi_file"
-fi
+    # Create rasi file if not exists
+    if [ ! -f $rasi_file ] ;then
+        touch $rasi_file
+        echo "* { current-image: url(\"~/$wallpaper_folder/default.jpg\", height); }" > "$rasi_file"
+    fi
+}
+
+echo -e "${GREEN}"
+figlet -f smslant "Wallpapers"
+echo -e "${NONE}"
+_find_wallpaper_folder_cache
+_confirm_wallpaper_folder
+_install_wallpapers
+_cache_wallpapers


### PR DESCRIPTION
Unfortunately I submitted a [broken PR](https://github.com/mylinuxforwork/dotfiles/pull/316) to be able to allow the user to set a custom wallpaper folder. Apologies for that, and I hope it didn't waste your time.

I've spent some more time in the repository, and have a better understanding of the flow of the setup process. This PR adds to the previous one in many ways:

1. Fixed incorrectly assuming a custom folder on first install.
2. Correctly persisted user override values using the `preparation.sh` stage.
3. Previous PR caused an issue where an error would show on first installation. This was because the command `wal` was getting an incorrect path to the default wallpaper. This has been fixed.

This implementation is entirely about this wallpaper feature, with one very small exception. During the `init-pywal.sh` execution, I have added the `-e` flag to the `wal` command. Without this there is a harsh reset of the terminal when the color scheme changes. This flag prevents the terminal from clearing. Specifically, the `-e` flag is described in `wal --help` as:

```sh
  -e                    Skip reloading gtk/xrdb/i3/sway/polybar
```

I have found this change very useful in being able to move the wallpapers folder off the home directory through installs and upgrades. I hope you also find it useful. I have done a lot more testing, and this works as expected on a fresh format of the drive, and subsequent calls to `bin/ml4w-hyprland-setup`. Again, I apologize for wasting your time with the previous pull request.

*Note:* This pull request requires a fix to the function `_replaceTextInFile`, which I have submitted a [pull request](https://github.com/mylinuxforwork/dotfiles/pull/320) for.