### PR TITLE
Conditionally use `figlet`

### DIFF
--- a/lib/install/packages/aur.sh
+++ b/lib/install/packages/aur.sh
@@ -67,7 +67,17 @@ _checkAURHelper() {
 }
 
 echo -e "${GREEN}"
-figlet -f smslant "AUR Helper"
+if [ -x figlet ] ;then
+    figlet -f smslant "AUR Helper"
+  else
+    cat <<"    EOF"
+   ___  __  _____      __ __    __            
+  / _ |/ / / / _ \    / // /__ / /__  ___ ____
+ / __ / /_/ / , _/   / _  / -_) / _ \/ -_) __/
+/_/ |_\____/_/|_|   /_//_/\__/_/ .__/\__/_/   
+                              /_/             
+    EOF
+fi
 echo -e "${NONE}"
 
 _checkAURHelper

--- a/lib/install/packages/packages.sh
+++ b/lib/install/packages/packages.sh
@@ -4,7 +4,17 @@
 
 if [[ $install_mode == "filesystem" ]] ;then
     echo -e "${GREEN}"
-    figlet -f smslant "Packages"
+    if [ -x figlet ] ;then
+        figlet -f smslant "Packages"
+    else
+        cat <<"        EOF"
+   ___           __                   
+  / _ \___ _____/ /_____ ____ ____ ___
+ / ___/ _ `/ __/  '_/ _ `/ _ `/ -_|_-<
+/_/   \_,_/\__/_/\_\\_,_/\_, /\__/___/
+                        /___/         
+        EOF
+    fi
     echo -e "${NONE}"
 
     # General packages


### PR DESCRIPTION
On a fresh Arch install the command `figlet` isn't available until the general packages are installed. This outputs the error `zsh: command not found: figlet`.

This commit checks if `figlet` is an available executable, otherwise the smslant style ASCII version of the output is echo'd.