### PR TITLE
Add ignore_empty_input to hyprlock config

### DIFF
--- a/share/dotfiles/.config/hypr/hyprlock.conf
+++ b/share/dotfiles/.config/hypr/hyprlock.conf
@@ -6,6 +6,10 @@
 #        |___/|_|                           
 # 
 
+general {
+    ignore_empty_input = true
+}
+
 background {
     monitor =
     path = $HOME/.config/ml4w/cache/blurred_wallpaper.png   # only png supported for now


### PR DESCRIPTION
This is a convenience PR.

If you lock your computer and press enter to wake up the monitors the default behavior of hyprlock is to treat that as a password verification attempt. By adding the `ignore_empty_input` setting to the hyperlock config nothing will happen when you press enter if the password field is empty.