### PR TITLE
fix 406: stores the content of keybindings variable in a file for reuse.

### DIFF
--- a/share/dotfiles/.config/hypr/scripts/keybindings.sh
+++ b/share/dotfiles/.config/hypr/scripts/keybindings.sh
@@ -1,47 +1,58 @@
 #!/bin/bash
-#  _              _     _           _ _                  
-# | | _____ _   _| |__ (_)_ __   __| (_)_ __   __ _ ___  
-# | |/ / _ \ | | | '_ \| | '_ \ / _` | | '_ \ / _` / __| 
-# |   <  __/ |_| | |_) | | | | | (_| | | | | | (_| \__ \ 
-# |_|\_\___|\__, |_.__/|_|_| |_|\__,_|_|_| |_|\__, |___/ 
-#           |___/                             |___/      
+#  _              _     _           _ _
+# | | _____ _   _| |__ (_)_ __   __| (_)_ __   __ _ ___
+# | |/ / _ \ | | | '_ \| | '_ \ / _` | | '_ \ / _` / __|
+# |   <  __/ |_| | |_) | | | | | (_| | | | | | (_| \__ \
+# |_|\_\___|\__, |_.__/|_|_| |_|\__,_|_|_| |_|\__, |___/
+#           |___/                             |___/
 #
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 # Get keybindings location based on variation
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 config_file=$(cat ~/.config/hypr/conf/keybinding.conf)
 config_file=${config_file/source = ~/}
 config_file=${config_file/source=~/}
 
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 # Path to keybindings config file
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 config_file="/home/$USER$config_file"
 echo "Reading from: $config_file"
 
+genretaed_filename="${config_file}_$(stat -c '%Y' $config_file).help"
+
 keybinds=""
 
-# Detect Start String
-while read -r line
-do
+## Check if the generated help file exists
+if [ -f "$genretaed_filename" ]; then
+  echo "Help file for $config_file already exists"
+  keybinds=$(cat "$genretaed_filename")
+else
+  echo "Generated help file not found. Removing $config_file*.help files"
+  echo "Generating help file for $config_file"
+  while read -r line; do
     if [[ "$line" == "bind"* ]]; then
 
-        line="$(echo "$line" | sed 's/$mainMod/SUPER/g')"
-        line="$(echo "$line" | sed 's/bind = //g')"
-        line="$(echo "$line" | sed 's/bindm = //g')"
+      line="$(echo "$line" | sed 's/$mainMod/SUPER/g')"
+      line="$(echo "$line" | sed 's/bind = //g')"
+      line="$(echo "$line" | sed 's/bindm = //g')"
 
-        IFS='#' 
-        read -a strarr <<<"$line" 
-        kb_str=${strarr[0]}
-        cm_str=${strarr[1]}
+      IFS='#'
+      read -a strarr <<<"$line"
+      kb_str=${strarr[0]}
+      cm_str=${strarr[1]}
 
-        IFS=',' 
-        read -a kbarr <<<"$kb_str" 
+      IFS=','
+      read -a kbarr <<<"$kb_str"
 
-        item="${kbarr[0]}  + ${kbarr[1]}"$'\r'"${cm_str:1}"
-        keybinds=$keybinds$item$'\n'
-    fi 
-done < "$config_file"
+      item="${kbarr[0]}  + ${kbarr[1]}"$'\r'"${cm_str:1}"
+      keybinds=$keybinds$item$'\n'
+    fi
+  done <"$config_file"
+  echo "$keybinds" >"$genretaed_filename"
+  rm -f "$config_file"*.help
+fi
 
 sleep 0.2
-rofi -dmenu -i -markup -eh 2 -replace -p "Keybinds" -config ~/.config/rofi/config-compact.rasi <<< "$keybinds"
+rofi -dmenu -i -markup -eh 2 -replace -p "Keybinds" -config ~/.config/rofi/config-compact.rasi <<<"$keybinds"
+

--- a/share/dotfiles/.config/hypr/scripts/keybindings.sh
+++ b/share/dotfiles/.config/hypr/scripts/keybindings.sh
@@ -28,8 +28,9 @@ if [ -f "$genretaed_filename" ]; then
   echo "Help file for $config_file already exists"
   keybinds=$(cat "$genretaed_filename")
 else
-  echo "Generated help file not found. Removing $config_file*.help files"
-  echo "Generating help file for $config_file"
+  echo "Generated help file with smilar modification time not found. Removing old $config_file*.help files"
+  rm -f "$config_file"*.help
+  echo "Generating new help file for $config_file"
   while read -r line; do
     if [[ "$line" == "bind"* ]]; then
 
@@ -50,9 +51,7 @@ else
     fi
   done <"$config_file"
   echo "$keybinds" >"$genretaed_filename"
-  rm -f "$config_file"*.help
 fi
 
 sleep 0.2
 rofi -dmenu -i -markup -eh 2 -replace -p "Keybinds" -config ~/.config/rofi/config-compact.rasi <<<"$keybinds"
-


### PR DESCRIPTION
This pull requests holds upgrade to `hypr/scripts/keybindings.sh` as i mentioned before on https://github.com/mylinuxforwork/dotfiles/issues/406.

1. Rather than generating the keybinds variable from the keybind .conf (eg. hypr/keybindings/default.conf) file each time hypr/scripts/keybindings.sh script is ran, it is be generated once after each modification to keybind .conf file selected by user.

2. This variable is saved as `[configfile.conf]_[unix_time_stamp].help` file. the unix time stamp indicates the last time the config file is modified. if it dosent match the _help_ file is regenerated according to the `keybinds` variable and older _.help_ file is removed. The .help extension might not be the best choice. and i am a bit confused with the extension name. Also the _help_ file is stored in the same directory as the conf direcotry. (eg `.config/hypr/conf/keybindings` by default)

This is my first PR in an open source project. Please do guide me if mistakes are made. 