### PR TITLE
Added a media Player for Sidebar

### DIFF
--- a/share/dotfiles/.config/ags/style.css
+++ b/share/dotfiles/.config/ags/style.css
@@ -13,14 +13,14 @@
     margin:14px;
     border-radius: 12px;
     font-weight: bold;
-    border: 3px solid @color11;
+    border: 3px solid @color5; /* this is pywal's colors you can put your custom colors you want */
     box-shadow: 0px 0px 10px 1px rgba(0, 0, 0, 0.8);
     padding:20px;
     min-width:320px;
 }
 
 calendar:selected {
-    background-color:@color11;
+    background-color:@color5;
     padding:0px;
 }
 
@@ -30,7 +30,7 @@ calendar:selected {
     margin:14px;
     border-radius: 12px;
     font-weight: bold;
-    border: 3px solid @color11;
+    border: 3px solid @color5;
     box-shadow: 0px 0px 10px 1px rgba(0, 0, 0, 0.8);
     padding:20px;
 }
@@ -66,21 +66,21 @@ calendar:selected {
 }
 
 .midbtn {
-    background-color: @color11;
+    background-color: @color5;
     font-size: 12px;
     padding:10px;
     border-radius: 20px;
 }
 
 .AudioSlider {
-    background-color:@color11;
+    background-color:@color5;
     border-radius:12px;
     margin-bottom:10px;
 }
 
 .AudioSlider contents {
     min-height: 20px;
-    background-color:@color15;
+    background-color:@color4;
     border-radius:12px;
 }
 
@@ -91,31 +91,31 @@ calendar:selected {
 
 .AudioSlider slider {
     min-height: 20px;
-    background-color:@color15;
+    background-color:@color4;
     border-radius:12px;
 }
 
 .AudioSlider highlight {
     min-height:20px;
-    background-color:@color11;
+    background-color:@color5;
     border-radius:12px;
     outline-width:3px;
 }
 
 .AudioSlider fill {
     min-height:20px;
-    background-color:@color11;
+    background-color:@color5;
     border-radius:12px;
 }
 
 .MicrophoneSlider {
-    background-color:@color11;
+    background-color:@color5;
     border-radius:12px;
 }
 
 .MicrophoneSlider contents {
     min-height: 20px;
-    background-color:@color15;
+    background-color:@color4;
     border-radius:12px;
 }
 
@@ -126,19 +126,71 @@ calendar:selected {
 
 .MicrophoneSlider slider {
     min-height: 20px;
-    background-color:@color15;
+    background-color:@color4;
     border-radius:12px;
 }
 
 .MicrophoneSlider highlight {
     min-height:20px;
-    background-color:@color11;
+    background-color:@color5;
     border-radius:12px;
     outline-width:3px;
 }
 
 .MicrophoneSlider fill {
     min-height:20px;
-    background-color:@color11;
+    background-color:@color5;
     border-radius:12px;
+}
+
+box.MediaPlayer {
+    padding: 20px;
+    background-color: rgba(116, 116, 116, 0.1);
+    border-radius: 20px;
+}
+
+box.MediaPlayer > box.cover-art {
+    min-width: 80px;
+    min-height: 80px;
+    border-radius: 7px;
+    margin-right: 0.6rem;
+    background-size: cover;
+    background-position: center;
+}
+
+box.MediaPlayer > box.title label {
+    font-weight: bold;
+    font-size: 1.1em;
+}
+
+box.MediaPlayer scale {
+    padding: 0;
+    margin: 0.4rem 0;
+}
+
+box.MediaPlayer scale trough {
+    border-radius: 10px;
+    background-color: #848282;
+    min-height: 8px;
+}
+
+box.MediaPlayer scale highlight {
+    border-radius: 10px;
+    background-color: @color5;
+}
+
+box.MediaPlayer scale slider {
+    all: inherit;
+}
+
+
+box.MediaPlayer > centerbox.actions {
+    min-width: 220px;
+}
+
+box.MediaPlayer > centerbox.actions > button {
+    min-width: 0;
+    min-height: 0;
+    padding: 0.4rem;
+    margin: 0 0.2rem;
 }

--- a/share/dotfiles/.config/ags/widget/Sidebar.tsx
+++ b/share/dotfiles/.config/ags/widget/Sidebar.tsx
@@ -3,6 +3,98 @@ import Apps from "gi://AstalApps"
 import Wp from "gi://AstalWp"
 import { Variable, GLib, bind, exec, execAsync } from "astal"
 import { Astal, Gtk, Gdk } from "astal/gtk3"
+import Mpris from "gi://AstalMpris"
+
+// taking length
+function lengthStr(length: number) {
+    const min = Math.floor(length / 60)
+    const sec = Math.floor(length % 60)
+    const sec0 = sec < 10 ? "0" : ""
+    return `${min}:${sec0}${sec}`
+}
+
+// used mrpis
+function MediaPlayer({ player }: { player: Mpris.Player }) {
+    const { START, END } = Gtk.Align
+
+    const title = bind(player, "title").as(t =>
+        t || "Unknown Track")
+
+    const artist = bind(player, "artist").as(a =>
+        a || "Unknown Artist")
+
+    const coverArt = bind(player, "coverArt").as(c =>
+        `background-image: url('${c}')`)
+
+        const validateEntry = (entry: string | null | undefined) => {
+            return entry && Astal.Icon.lookup_icon(entry) ? entry : "audio-x-generic-symbolic";
+        };
+        
+        const playerIcon = bind(player, "entry").as(validateEntry);
+        
+        
+
+    const position = bind(player, "position").as(p => player.length > 0
+        ? p / player.length : 0)
+
+    const playIcon = bind(player, "playbackStatus").as(s =>
+        s === Mpris.PlaybackStatus.PLAYING
+            ? "media-playback-pause-symbolic"
+            : "media-playback-start-symbolic"
+    )
+
+    return <box className="MediaPlayer">
+        <box className="cover-art" css={coverArt} />
+        <box className="hi" vertical>
+            <box className="title">
+                <label truncate hexpand halign={START} label={title} />
+                <icon icon={playerIcon} />
+            </box>
+            <label halign={START} valign={START} vexpand wrap label={artist} />
+            <slider
+                visible={bind(player, "length").as(l => l > 0)}
+                onDragged={({ value }) => player.position = value * player.length}
+                value={position}
+            />
+            <centerbox className="actions">
+                <label
+                    hexpand
+                    className="position"
+                    halign={START}
+                    visible={bind(player, "length").as(l => l > 0)}
+                    label={bind(player, "position").as(lengthStr)}
+                />
+                <box>
+                    <button
+                    css={"padding-right: 15px"}
+                        onClicked={() => player.previous()}
+                        visible={bind(player, "canGoPrevious")}>
+                        <icon icon="media-skip-backward-symbolic" />
+                    </button>
+                    <button
+                        onClicked={() => player.play_pause()}
+                        visible={bind(player, "canControl")}>
+                        <icon icon={playIcon} />
+                    </button>
+                    <button
+                    css={"padding-left: 15px"}
+                        onClicked={() => player.next()}
+                        visible={bind(player, "canGoNext")}>
+                        <icon icon="media-skip-forward-symbolic" />
+                    </button>
+                </box>
+                <label
+                    hexpand
+                    className="length"
+                    halign={END}
+                    visible={bind(player, "length").as(l => l > 0)}
+                    label={bind(player, "length").as(l => l > 0 ? lengthStr(l) : "0:00")}
+                />
+            </centerbox>
+        </box>
+    </box>
+}
+
 
 function AudioSlider() {
     const speaker = Wp.get_default()?.audio.defaultSpeaker!
@@ -59,7 +151,7 @@ function openwaybarthemes() {
 }
 
 export default function Sidebar() {
-
+    const mpris = Mpris.get_default()
     const anchor = Astal.WindowAnchor.TOP
         | Astal.WindowAnchor.RIGHT
 
@@ -71,6 +163,18 @@ export default function Sidebar() {
     anchor={anchor}
     >    
     <box className="sidebar" vertical>
+
+{/* you can just cut the lines 169-176 and paste it according to your need of postion in the sidebar */}
+
+    {bind(mpris, "players").as(arr => {
+    const lastPlayer = arr[arr.length - 1]; // Get the last index of the array (you will get alot of players, the last one has all the metadata of the current playing song)
+    return lastPlayer ? (
+        <box css={"margin-bottom: 20px"} halign="left" vertical>
+            <MediaPlayer player={lastPlayer} />
+        </box>
+    ) : null; // Return null if the array is empty
+})}
+
         <box css="padding-bottom:20px;">
             <box className="group" vertical>
                 <box homogeneous>
@@ -102,6 +206,7 @@ export default function Sidebar() {
             <label css="padding-bottom:10px" label="Microphone"></label>
             <MicrophoneSlider />
         </box>
+        
     </box>
 </window>
 }

--- a/share/dotfiles/.config/ags/widget/Sidebar.tsx
+++ b/share/dotfiles/.config/ags/widget/Sidebar.tsx
@@ -168,7 +168,6 @@ export default function Sidebar() {
 
     {bind(mpris, "players").as(arr => {
         const lastPlayer = arr[arr.length - 1]; // Get the last index of the array (you will get alot of players, the last one has all the metadata of the current playing song)
-        console.log(lastPlayer)
         if(lastPlayer === undefined){
             return <></>
         } else {

--- a/share/dotfiles/.config/ags/widget/Sidebar.tsx
+++ b/share/dotfiles/.config/ags/widget/Sidebar.tsx
@@ -164,15 +164,19 @@ export default function Sidebar() {
     >    
     <box className="sidebar" vertical>
 
-{/* you can just cut the lines 169-176 and paste it according to your need of postion in the sidebar */}
+{/* you can just cut the lines 169-180 and paste it according to your need of postion in the sidebar */}
 
     {bind(mpris, "players").as(arr => {
-    const lastPlayer = arr[arr.length - 1]; // Get the last index of the array (you will get alot of players, the last one has all the metadata of the current playing song)
-    return lastPlayer ? (
-        <box css={"margin-bottom: 20px"} halign="left" vertical>
-            <MediaPlayer player={lastPlayer} />
-        </box>
-    ) : null; // Return null if the array is empty
+        const lastPlayer = arr[arr.length - 1]; // Get the last index of the array (you will get alot of players, the last one has all the metadata of the current playing song)
+        console.log(lastPlayer)
+        if(lastPlayer === undefined){
+            return <></>
+        } else {
+            return (
+                <box css={"margin-bottom: 20px"} halign="left" vertical>
+                <MediaPlayer player={lastPlayer} />
+            </box>
+        )}
 })}
 
         <box css="padding-bottom:20px;">


### PR DESCRIPTION
Added MediaPlayer using Mpris that will catch any music being played from spotify to chrome inside Sidebar.
The position of the MediaPlayer can be changed if the lines 169-176 be moved downwards. (currently above everything).
Inspo taken from the example in astal's website.