### PR TITLE
The Waybar `launch.sh` to source the `.bashrc`

### DIFF
--- a/share/dotfiles/.config/waybar/launch.sh
+++ b/share/dotfiles/.config/waybar/launch.sh
@@ -8,6 +8,16 @@
 # by Stephan Raabe (2023) 
 # ----------------------------------------------------- 
 
+
+# ----------------------------------------------------- 
+# Load `.bashrc` to support use-cases for custom Waybar
+# modules where the user commands require additional
+# setup that is provided by `.bashrc`. Common use-cases
+# include running Python scripts from a specific `venv`
+# or custom JVM environments.
+# ----------------------------------------------------- 
+source ~/.bashrc
+
 # ----------------------------------------------------- 
 # Quit all running waybar instances
 # ----------------------------------------------------- 


### PR DESCRIPTION
Supports use-cases for custom Python `venvs`, for example, for plugins like `nextmeeting`.