### PR TITLE
Enclose wallpaper path when using pywal

### DIFF
--- a/share/dotfiles/.config/hypr/scripts/wallpaper.sh
+++ b/share/dotfiles/.config/hypr/scripts/wallpaper.sh
@@ -118,7 +118,7 @@ pkill waybar
 # ----------------------------------------------------- 
 
 echo ":: Execute pywal with $used_wallpaper"
-wal -q -i $used_wallpaper
+wal -q -i "$used_wallpaper"
 source "$HOME/.cache/wal/colors.sh"
 
 # ----------------------------------------------------- 


### PR DESCRIPTION
Wallpaper paths with spaces may be misinterpreted by pywal as being multiple CLI arguments (failing the color palette generation). A simple enclosure in quotations solves most of the error cases.