### PR TITLE
Fix output of updates.sh

### DIFF
--- a/share/dotfiles/.config/ml4w/scripts/updates.sh
+++ b/share/dotfiles/.config/ml4w/scripts/updates.sh
@@ -60,7 +60,7 @@ if [ "$updates" -gt $threshhold_red ]; then
 fi
 
 if [ "$updates" -gt $threshhold_green ]; then
-    printf '{"text": "%s", "alt": "%s", "tooltip": "Click to update your system", "class": "%s"}' "$updates" "$updates" "$updates" "$css_class"
+    printf '{"text": "%s", "alt": "%s", "tooltip": "Click to update your system", "class": "%s"}' "$updates" "$updates" "$css_class"
 else
     printf '{"text": "0", "alt": "0", "tooltip": "No updates available", "class": "green"}'
 fi


### PR DESCRIPTION
The printf only has 3 `%s` placeholders, but there are 4 strings being passed in, which is incorrect.
The consequence seems to mostly have been just disabling the color in the waybar output.