### PR TITLE
Make checking for updates on arch faster/better

### DIFF
--- a/share/dotfiles/.config/ml4w/scripts/updates.sh
+++ b/share/dotfiles/.config/ml4w/scripts/updates.sh
@@ -25,17 +25,9 @@ case $install_platform in
         # Calculate available updates
         # ----------------------------------------------------- 
 
-        if ! updates_arch=$(checkupdates 2> /dev/null | wc -l ); then
-            updates_arch=0
-        fi
-
-        if ! updates_aur=$($aur_helper -Qu --aur --quiet | wc -l); then
-            updates_aur=0
-        fi
-
         # flatpak remote-ls --updates
 
-        updates=$(("$updates_arch" + "$updates_aur"))
+        updates=$(checkupdates-with-aur | wc -l)
     ;;
     fedora)
         updates=$(dnf check-update -q|grep -c ^[a-z0-9])

--- a/share/packages/arch/profiles/default.sh
+++ b/share/packages/arch/profiles/default.sh
@@ -52,4 +52,5 @@ packages=(
     "aylurs-gtk-shell" 
     "nwg-dock-hyprland"
     "oh-my-posh-bin"
+    "checkupdates-with-aur"
 );


### PR DESCRIPTION
The script you wrote to check for updates can be improved, atm it checks updates with the package `checkupdates` and `yay -Qu --aur --quiet`, while this can be combined in 1 command: `yay -Qu`, but the aur package `checkupdates-with-aur` does the same and is around a second faster, this is my 1st pull request, is adding the package to `share/packages/arch/profiles/default.sh` correct?