### PR TITLE
feat: Blur is added to the waybar from a layerrule, this way the wayb…

### DIFF
--- a/share/dotfiles/.config/hypr/conf/custom.conf
+++ b/share/dotfiles/.config/hypr/conf/custom.conf
@@ -19,3 +19,6 @@ env = SDL_VIDEODRIVER,wayland
 # cursor {
 #     no_hardware_cursors = false
 # }
+
+# Blur for waybar
+#layerrule = blur, waybar

--- a/share/dotfiles/.config/hypr/conf/ml4w.conf
+++ b/share/dotfiles/.config/hypr/conf/ml4w.conf
@@ -88,9 +88,6 @@ windowrulev2 = size 1000 700,class:(dotfiles-floating)
 windowrulev2 = center,class:(dotfiles-floating)
 windowrulev2 = pin, class:(dotfiles-floating)
 
-# Blur for waybar
-#layerrule = blur, waybar
-
 # XDG Desktop Portal
 env = XDG_CURRENT_DESKTOP,Hyprland
 env = XDG_SESSION_TYPE,wayland

--- a/share/dotfiles/.config/hypr/conf/ml4w.conf
+++ b/share/dotfiles/.config/hypr/conf/ml4w.conf
@@ -88,6 +88,9 @@ windowrulev2 = size 1000 700,class:(dotfiles-floating)
 windowrulev2 = center,class:(dotfiles-floating)
 windowrulev2 = pin, class:(dotfiles-floating)
 
+# Blur for waybar
+#layerrule = blur, waybar
+
 # XDG Desktop Portal
 env = XDG_CURRENT_DESKTOP,Hyprland
 env = XDG_SESSION_TYPE,wayland


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/31a63ec7-f423-4d45-9d66-42796d7de18c)

Blur is added to the waybar from a layerrule, this way the waybar uses the blur configured in Hyprland (It is recommended to configure the background-color property in the waybar theme css file with opacity 0.1 to correctly display the effect).

Commented for now, enable as needed.

In my setup, I use a custom theme, based on ml4w-modern white with the background-color property set to white with opacity 0.
