### PR TITLE
feat: New keybindings to add more options to window management

### DIFF
--- a/share/dotfiles/.config/hypr/conf/keybindings/default.conf
+++ b/share/dotfiles/.config/hypr/conf/keybindings/default.conf
@@ -18,7 +18,8 @@ bind = $mainMod CTRL, C, exec, ~/.config/ml4w/settings/calculator.sh # Open the 
 # Windows
 bind = $mainMod, Q, killactive # Kill active window
 bind = $mainMod SHIFT, Q, exec, hyprctl activewindow | grep pid | tr -d 'pid:'| xargs kill
-bind = $mainMod, F, fullscreen # Set active window to fullscreen
+bind = $mainMod, F, fullscreen, 0 # Set active window to fullscreen
+bind = $mainMod, M, fullscreen, 1
 bind = $mainMod, T, togglefloating # Toggle active windows into floating mode
 bind = $mainMod SHIFT, T, exec, $HYPRSCRIPTS/toggleallfloat.sh # Toggle all windows into floating mode
 bind = $mainMod, J, togglesplit # Toggle split

--- a/share/dotfiles/.config/hypr/conf/keybindings/default.conf
+++ b/share/dotfiles/.config/hypr/conf/keybindings/default.conf
@@ -17,6 +17,7 @@ bind = $mainMod CTRL, C, exec, ~/.config/ml4w/settings/calculator.sh # Open the 
 
 # Windows
 bind = $mainMod, Q, killactive # Kill active window
+bind = $mainMod SHIFT, Q, exec, hyprctl activewindow | grep pid | tr -d 'pid:'| xargs kill
 bind = $mainMod, F, fullscreen # Set active window to fullscreen
 bind = $mainMod, T, togglefloating # Toggle active windows into floating mode
 bind = $mainMod SHIFT, T, exec, $HYPRSCRIPTS/toggleallfloat.sh # Toggle all windows into floating mode


### PR DESCRIPTION
There is currently a keyboard shortcut to close only one window ($mainMod, Q). A new keyboard shortcut is added to do a "killall" to the program associated with the active window, this way, all its windows are closed and not just the focused one.