### PR TITLE
feat: New configuration files for workspace rules

### DIFF
--- a/share/dotfiles/.config/hypr/conf/workspace.conf
+++ b/share/dotfiles/.config/hypr/conf/workspace.conf
@@ -1,0 +1,1 @@
+source = workspaces/default.conf

--- a/share/dotfiles/.config/hypr/conf/workspaces/default.conf
+++ b/share/dotfiles/.config/hypr/conf/workspaces/default.conf
@@ -1,0 +1,19 @@
+# __        __         _                                  
+# \ \      / /__  _ __| | _____ _ __   __ _  ___ ___  ___ 
+#  \ \ /\ / / _ \| '__| |/ / __| '_ \ / _` |/ __/ _ \/ __|
+#   \ V  V / (_) | |  |   <\__ \ |_) | (_| | (_|  __/\__ \
+#  __\_/\_/ \___/|_|  |_|\_\___/ .__/ \__,_|\___\___||___/
+# |  _ \ _   _| | ___  ___     |_|                        
+# | |_) | | | | |/ _ \/ __|                               
+# |  _ <| |_| | |  __/\__ \                               
+# |_| \_\\__,_|_|\___||___/                               
+
+# Here are some configuration examples for workspaces
+
+# Set Master Layout orientation to "left" for workspace 1
+# workspace = 1, layoutopt:orientation:left
+
+# When the workspace is recreated, the defined program is automatically launched, in this case "kitty"
+# workspace = 1, on-created-empty: kitty
+
+

--- a/share/dotfiles/.config/hypr/hyprland.conf
+++ b/share/dotfiles/.config/hypr/hyprland.conf
@@ -56,6 +56,11 @@ source = ~/.config/hypr/conf/windowrule.conf
 source = ~/.config/hypr/conf/animation.conf
 
 # ----------------------------------------------------- 
+# Workspaces
+# ----------------------------------------------------- 
+source = ~/.config/hypr/conf/workspace.conf
+
+# ----------------------------------------------------- 
 # Environment for xdg-desktop-portal-hyprland
 # ----------------------------------------------------- 
 exec-once=dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP


### PR DESCRIPTION
New configuration files for workspace rules, called from "hyprland.conf". Sample configurations are included in the files.

If necessary, consider adding these new files to the configuration scripts for this customization layer.