### PR TITLE
Remove duplicate config options

### DIFF
--- a/share/dotfiles/.config/waybar/themes/ml4w-blur/config
+++ b/share/dotfiles/.config/waybar/themes/ml4w-blur/config
@@ -13,7 +13,6 @@
     "layer": "top",
     "margin-top": 0,
     "margin-bottom": 0,
-    "layer": "top",
     "margin-left": 0,
     "margin-right": 0,    
     "spacing": 0,

--- a/share/dotfiles/.config/waybar/themes/ml4w-minimal/config
+++ b/share/dotfiles/.config/waybar/themes/ml4w-minimal/config
@@ -12,7 +12,6 @@
     // General Settings
     "layer": "top",
     "margin-bottom": 0,
-    "layer": "top",
     "margin-left": 0,
     "margin-right": 0,    
     "spacing": 0,

--- a/share/dotfiles/.config/waybar/themes/starter/config
+++ b/share/dotfiles/.config/waybar/themes/starter/config
@@ -20,7 +20,6 @@
     // "margin-top": 0,
     // "margin-bottom": 14,
     
-    "layer": "top",
     "margin-left": 0,
     "margin-right": 0,    
     "spacing": 0,


### PR DESCRIPTION
Duplicate `layer:top `declarations removed from theme config files.