### PR TITLE
Tooltip for hypridle inhibit - no right click

### DIFF
--- a/share/dotfiles/.config/hypr/scripts/hypridle.sh
+++ b/share/dotfiles/.config/hypr/scripts/hypridle.sh
@@ -11,9 +11,9 @@ SERVICE="hypridle"
 if [[ "$1" == "status" ]]; then
     sleep 1
     if pgrep -x "$SERVICE" >/dev/null ;then
-        echo '{"text": "RUNNING", "class": "active", "tooltip": "Screen locking active\nLeft: Deactivate\nRight: Lock Screen"}'
+        echo '{"text": "RUNNING", "class": "active", "tooltip": "Screen locking active\nLeft: Deactivate"}'
     else
-        echo '{"text": "NOT RUNNING", "class": "notactive", "tooltip": "Screen locking deactivated\nLeft: Activate\nRight: Lock Screen"}'
+        echo '{"text": "NOT RUNNING", "class": "notactive", "tooltip": "Screen locking deactivated\nLeft: Activate"}'
     fi
 fi
 if [[ "$1" == "toggle" ]]; then


### PR DESCRIPTION
After [this commit](https://github.com/mylinuxforwork/dotfiles/commit/7864b73f0b726df8cc5383ebcddff9cdbf05e66d), right clicking on the hypridle inhibit module no longer does anything, but the tooltip was not updated.