### PR TITLE
Add --needed flag to package installation

### DIFF
--- a/lib/install/nvidia.sh
+++ b/lib/install/nvidia.sh
@@ -26,7 +26,7 @@ if [[ $nvidia =~ ^[Yy]$ ]]; then
   )
   for krnl in $(cat /usr/lib/modules/*/pkgbase); do
     for pkg in "${krnl}-headers" "${nvidia_pkgs[@]}"; do
-      $aur_helper -S --noconfirm "$pkg"
+      $aur_helper -S --noconfirm --needed "$pkg"
     done
   done
 


### PR DESCRIPTION
Updated the package installation loop to include the `--needed` flag, preventing reinstallation of already installed packages.