### PR TITLE
Add 'quiet' and 'splash' to systemd-boot, tweak pacman config

### DIFF
--- a/lib/install/nvidia.sh
+++ b/lib/install/nvidia.sh
@@ -52,8 +52,8 @@ if [[ $nvidia =~ ^[Yy]$ ]]; then
     if [ $(ls -l /boot/loader/entries/*.conf.t2.bkp 2>/dev/null | wc -l) -ne $(ls -l /boot/loader/entries/*.conf 2>/dev/null | wc -l) ]; then
       find /boot/loader/entries/ -type f -name "*.conf" | while read imgconf; do
         sudo cp ${imgconf} ${imgconf}.t2.bkp
-        sdopt=$(grep -w "^options" ${imgconf} | sed 's/\b nvidia-drm.modeset=.\b//g' | sed 's/\b nvidia_drm.fbdev=.\b//g')
-        sudo sed -i "/^options/c${sdopt} nvidia-drm.modeset=1 nvidia_drm.fbdev=1" ${imgconf}
+        sdopt=$(grep -w "^options" ${imgconf} | sed 's/\b quiet\b//g' | sed 's/\b splash\b//g' | sed 's/\b nvidia-drm.modeset=.\b//g' | sed 's/\b nvidia_drm.fbdev=.\b//g')
+        sudo sed -i "/^options/c${sdopt} quiet splash nvidia-drm.modeset=1 nvidia_drm.fbdev=1" ${imgconf}
       done
     else
       echo "systemd-boot is already configured..."
@@ -70,5 +70,3 @@ if [[ $nvidia =~ ^[Yy]$ ]]; then
 else
   _writeSkipped
 fi
-
-

--- a/setup-arch.sh
+++ b/setup-arch.sh
@@ -145,6 +145,23 @@ fi
 sudo pacman -Sy
 echo
 
+# pacman
+if [ -f /etc/pacman.conf ] && [ ! -f /etc/pacman.conf.t2.bkp ]; then
+    echo -e "\033[0;32m[PACMAN]\033[0m adding extra spice to pacman..."
+
+    sudo cp /etc/pacman.conf /etc/pacman.conf.t2.bkp
+    sudo sed -i "/^#Color/c\Color\nILoveCandy
+    /^#VerbosePkgLists/c\VerbosePkgLists
+    /^#ParallelDownloads/c\ParallelDownloads = 5" /etc/pacman.conf
+    sudo sed -i '/^#\[multilib\]/,+1 s/^#//' /etc/pacman.conf
+
+    sudo pacman -Syyu
+    sudo pacman -Fy
+
+else
+    echo -e "\033[0;33m[SKIP]\033[0m pacman is already configured..."
+fi
+
 # Install required packages
 echo ":: Checking that required packages are installed..."
 _installPackages "${packages[@]}";


### PR DESCRIPTION
- Introduced a script section to optimize pacman configuration by enabling features like parallel downloads, verbose package lists, and the "ILoveCandy" aesthetic.
- Backed up the original pacman configuration to prevent data loss.
- Automatically updated pacman’s configuration only if it hasn’t been previously modified.
- Ensured that pacman performs a system update and package database refresh after the changes.