### PR TITLE
Review of Changes between main and 2.9.7.4

### DIFF
--- a/lib/dev/apps.sh
+++ b/lib/dev/apps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dotfiles="/home/raabe/.ml4w-hyprland/dotfiles"
+dotfiles="$HOME/.ml4w-hyprland/dotfiles"
 
 # apps
 $dotfiles/lib/install/dotfiles/flatpak.sh $dotfiles/share/apps dev

--- a/lib/dev/install.sh
+++ b/lib/dev/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dotfiles="/home/raabe/.ml4w-hyprland/dotfiles"
+dotfiles="$HOME/.ml4w-hyprland/dotfiles"
 
 # share
 sudo cp -r $dotfiles/share/. /usr/share/ml4w-hyprland


### PR DESCRIPTION
Use $HOME insteed of absolute path.

If I interpret the changes correctly, will there be a dependency on flatpacks with the next version?

I have to admit that I'm not really happy about this, as I've been able to avoid it so far.

ML4W would then be the only extension in my system with this dependency.

Will there also be a version without this dependency?

Best regards from Munich.
