### PR TITLE
Adding loupe - gnome image viewer

### DIFF
--- a/share/packages/arch/options/other.sh
+++ b/share/packages/arch/options/other.sh
@@ -1,3 +1,4 @@
 optdepends=(
     "gnome-calculator"
+    "loupe"
 )

--- a/share/packages/arch/profiles/addons.sh
+++ b/share/packages/arch/profiles/addons.sh
@@ -4,4 +4,5 @@ packages=(
     "nautilus-open-any-terminal"
     "gnome-text-editor"
     "gnome-calculator"
+    "loupe"
 )

--- a/share/packages/arch/profiles/default.sh
+++ b/share/packages/arch/profiles/default.sh
@@ -53,4 +53,5 @@ packages=(
     "nwg-dock-hyprland"
     "oh-my-posh-bin"
     "checkupdates-with-aur"
+    "loupe"
 )


### PR DESCRIPTION
# Adding [loupe](https://apps.gnome.org/Loupe/) - gnome image viewer

> My apologies as I do not know what other files to edit to add this feature/package to ml4w. Still figuring it out.

### Reason for adding

I have noticed from the 3 times I installed ml4w that every time I want to **view an image** (especially in Nautilus or Dolphin) **the image opens in Firefox**. Sometimes I don't even realize that the image is already showing in Firefox because is no indication of it if not unless you are in the same window.

I have searched to look for the **most lightweight, quick. and stable image viewer** I can find that I can just use to view an image (_nothing too fancy_) and I found that **gnome as an image view** and it is called `loupe` in pacman.

I have been using it and it is good as a default image viewer, users can use whatever image viewer they want to add later but at least this is **better than viewing images in a browser.**