### PR TITLE
Add basic media packages to default installation

### DIFF
--- a/share/packages/arch/profiles/addons.sh
+++ b/share/packages/arch/profiles/addons.sh
@@ -1,8 +1,11 @@
 packages=(
-    "firefox"
-    "nautilus"
-    "nautilus-open-any-terminal"
-    "gnome-text-editor"
-    "gnome-calculator"
-    "loupe"
+  "firefox"
+  "nautilus"
+  "nautilus-open-any-terminal"
+  "gnome-text-editor"
+  "gnome-calculator"
+  "loupe"
+  "mpv"
+  "imv"
+  "ffmpegthumbnailer"
 )

--- a/share/packages/fedora/profiles/addons.sh
+++ b/share/packages/fedora/profiles/addons.sh
@@ -1,7 +1,10 @@
 packages=(
-    "firefox"
-    "nautilus"
-    "nautilus-open-any-terminal"
-    "gnome-text-editor"
-    "gnome-calculator"
+  "firefox"
+  "nautilus"
+  "nautilus-open-any-terminal"
+  "gnome-text-editor"
+  "gnome-calculator"
+  "mpv"
+  "imv"
+  "ffmpegthumbnailer"
 )


### PR DESCRIPTION

Adds essential media functionality out of the box:
- mpv: Standard video player for Wayland with native protocol support
- imv: Simple image viewer for Wayland
- ffmpegthumbnailer: Enable video thumbnails in file managers

