### PR TITLE
Save screenshots to "$HOME/Pictures/screenshots/"

### DIFF
--- a/share/dotfiles/.config/ml4w/settings/screenshot-folder.sh
+++ b/share/dotfiles/.config/ml4w/settings/screenshot-folder.sh
@@ -1,1 +1,1 @@
-screenshot_folder="$HOME/Pictures"
+screenshot_folder="$HOME/Pictures/screenshots/"


### PR DESCRIPTION
# Save screenshots to "$HOME/Pictures/screenshots/"

## Changes:

- Use Save screenshots to `$HOME/Pictures/screenshots/` directory to save screenshots instead of just the Save screenshots to `$HOME/Pictures/`

### Reason

Saving it only in the `Pictures` directory will lead to a mess of screenshots and other pictures. This change keeps things organized.