### PR TITLE
Removed a repeated icon from ml4w-blur waybar theme

### DIFF
--- a/share/dotfiles/.config/waybar/themes/ml4w-blur/config
+++ b/share/dotfiles/.config/waybar/themes/ml4w-blur/config
@@ -44,7 +44,6 @@
         "pulseaudio",
         //"backlight",
         "bluetooth",
-        "battery", 
         "network",
         "battery", 
         "power-profiles-daemon",


### PR DESCRIPTION
Battery icon was doubled in config.