### PR TITLE
Fix: Updated widowrule syntax to adhere to windowrulev2 as per hyprland release notes

### DIFF
--- a/share/dotfiles/.config/hypr/conf/windowrules/default.conf
+++ b/share/dotfiles/.config/hypr/conf/windowrules/default.conf
@@ -2,13 +2,13 @@
 # Window rules
 # -----------------------------------------------------
 
-windowrule = tile, title:^(Microsoft-edge)$
-windowrule = tile, title:^(Brave-browser)$
-windowrule = tile, title:^(Chromium)$
-windowrule = float, title:^(pavucontrol)$
-windowrule = float, title:^(blueman-manager)$
-windowrule = float, title:^(nm-connection-editor)$
-windowrule = float, title:^(qalculate-gtk)$
+windowrule = tile, class:Microsoft-edge
+windowrule = tile, class:Brave-browser
+windowrule = tile, class:Chromium
+windowrule = float, class:pavucontrol
+windowrule = float, class:blueman-manager
+windowrule = float, class:nm-connection-editor
+windowrule = float, class:qalculate-gtk
 
 # Browser Picture in Picture
 windowrule = float, title:^(Picture-in-Picture)$


### PR DESCRIPTION
# fix: widowrule syntax to adhere to windowrulev2

As per [the new Hyprland update release notes](https://github.com/hyprwm/Hyprland/releases/tag/v0.48.0), we have these breaking changes

Breaking changes:
- windowrule v1 syntax is gone. windowrule now behaves like windowrulev2, deprecating the windowrulev2 keyword