### PR TITLE
Fix: update windowrule syntax

### DIFF
--- a/share/dotfiles/.config/hypr/conf/ml4w.conf
+++ b/share/dotfiles/.config/hypr/conf/ml4w.conf
@@ -5,22 +5,22 @@
 #
 
 # Pavucontrol floating
-windowrulev2 = float,class:(.*org.pulseaudio.pavucontrol.*)
-windowrulev2 = size 700 600,class:(.*org.pulseaudio.pavucontrol.*)
-windowrulev2 = center,class:(.*org.pulseaudio.pavucontrol.*)
-windowrulev2 = pin,class:(.*org.pulseaudio.pavucontrol.*)
+windowrule = float,class:(.*org.pulseaudio.pavucontrol.*)
+windowrule = size 700 600,class:(.*org.pulseaudio.pavucontrol.*)
+windowrule = center,class:(.*org.pulseaudio.pavucontrol.*)
+windowrule = pin,class:(.*org.pulseaudio.pavucontrol.*)
 
 # OpenAI ChatGPT floating
-windowrulev2 = float,title:(ChatGPT.*)
-windowrulev2 = float,title:(.*chat.openai.com.*)
-windowrulev2 = size 500 50%,title:(.*chat.openai.com.*)
-windowrulev2 = move 20 70,title:(.*chat.openai.com.*)
+windowrule = float,title:(ChatGPT.*)
+windowrule = float,title:(.*chat.openai.com.*)
+windowrule = size 500 50%,title:(.*chat.openai.com.*)
+windowrule = move 20 70,title:(.*chat.openai.com.*)
 
 # Waypaper
-windowrulev2 = float,class:(.*waypaper.*)
-windowrulev2 = size 900 700,class:(.*waypaper.*)
-windowrulev2 = center,class:(.*waypaper.*)
-windowrulev2 = pin,class:(.*waypaper.*)
+windowrule = float,class:(.*waypaper.*)
+windowrule = size 900 700,class:(.*waypaper.*)
+windowrule = center,class:(.*waypaper.*)
+windowrule = pin,class:(.*waypaper.*)
 
 # SwayNC
 layerrule = blur, swaync-control-center
@@ -31,74 +31,74 @@ layerrule = ignorealpha 0.5, swaync-control-center
 layerrule = ignorealpha 0.5, swaync-notification-window
 
 # ML4W Calendar floating
-windowrulev2 = move 100%-w-16 66,class:(com.ml4w.calendar)
-windowrulev2 = pin, class:(com.ml4w.calendar)
+windowrule = move 100%-w-16 66,class:(com.ml4w.calendar)
+windowrule = pin, class:(com.ml4w.calendar)
 
 # ML4W Sidebar floating
-windowrulev2 = move 100%-w-16 66,class:(com.ml4w.sidebar)
-windowrulev2 = pin, class:(com.ml4w.sidebar)
+windowrule = move 100%-w-16 66,class:(com.ml4w.sidebar)
+windowrule = pin, class:(com.ml4w.sidebar)
 
 # ML4W Welcome App floating
-windowrulev2 = float,class:(com.ml4w.welcome)
-windowrulev2 = size 700 600,class:(com.ml4w.welcome)
-windowrulev2 = center,class:(com.ml4w.welcome)
-windowrulev2 = pin,class:(com.ml4w.welcome)
+windowrule = float,class:(com.ml4w.welcome)
+windowrule = size 700 600,class:(com.ml4w.welcome)
+windowrule = center,class:(com.ml4w.welcome)
+windowrule = pin,class:(com.ml4w.welcome)
 
 # ML4W Settings App floating
-windowrulev2 = float,class:(com.ml4w.settings)
-windowrulev2 = size 700 600,class:(com.ml4w.settings)
-windowrulev2 = move 10% 20%,class:(com.ml4w.settings)
+windowrule = float,class:(com.ml4w.settings)
+windowrule = size 700 600,class:(com.ml4w.settings)
+windowrule = move 10% 20%,class:(com.ml4w.settings)
 
 # nwg-look
-windowrulev2 = float,class:(nwg-look)
-windowrulev2 = size 700 600,class:(nwg-look)
-windowrulev2 = move 10% 20%,class:(nwg-look)
-windowrulev2 = pin,class:(nwg-look)
+windowrule = float,class:(nwg-look)
+windowrule = size 700 600,class:(nwg-look)
+windowrule = move 10% 20%,class:(nwg-look)
+windowrule = pin,class:(nwg-look)
 
 # nwg-look
-windowrulev2 = float,class:(nwg-displays)
-windowrulev2 = size 700 600,class:(nwg-displays)
-windowrulev2 = move 10% 20%,class:(nwg-displays)
-windowrulev2 = pin,class:(nwg-displays)
+windowrule = float,class:(nwg-displays)
+windowrule = size 700 600,class:(nwg-displays)
+windowrule = move 10% 20%,class:(nwg-displays)
+windowrule = pin,class:(nwg-displays)
 
 # System Mission Center
-windowrulev2 = float, class:(io.missioncenter.MissionCenter)
-windowrulev2 = pin, class:(io.missioncenter.MissionCenter)
-windowrulev2 = center, class:(io.missioncenter.MissionCenter)
-windowrulev2 = size 900 600, class:(io.missioncenter.MissionCenter)
+windowrule = float, class:(io.missioncenter.MissionCenter)
+windowrule = pin, class:(io.missioncenter.MissionCenter)
+windowrule = center, class:(io.missioncenter.MissionCenter)
+windowrule = size 900 600, class:(io.missioncenter.MissionCenter)
 
 # System Mission Center Preference Window
-windowrulev2 = float, class:(missioncenter), title:^(Preferences)$
-windowrulev2 = pin, class:(missioncenter), title:^(Preferences)$
-windowrulev2 = center, class:(missioncenter), title:^(Preferences)$
+windowrule = float, class:(missioncenter), title:^(Preferences)$
+windowrule = pin, class:(missioncenter), title:^(Preferences)$
+windowrule = center, class:(missioncenter), title:^(Preferences)$
 
 # Gnome Calculator
-windowrulev2 = float,class:(org.gnome.Calculator)
-windowrulev2 = size 700 600,class:(org.gnome.Calculator)
-windowrulev2 = center,class:(org.gnome.Calculator)
+windowrule = float,class:(org.gnome.Calculator)
+windowrule = size 700 600,class:(org.gnome.Calculator)
+windowrule = center,class:(org.gnome.Calculator)
 
 # Emoji Picker Smile
-windowrulev2 = float,class:(it.mijorus.smile)
-windowrulev2 = pin, class:(it.mijorus.smile)
-windowrulev2 = move 100%-w-40 90,class:(it.mijorus.smile)
+windowrule = float,class:(it.mijorus.smile)
+windowrule = pin, class:(it.mijorus.smile)
+windowrule = move 100%-w-40 90,class:(it.mijorus.smile)
 
 # Hyprland Share Picker
-windowrulev2 = float, class:(hyprland-share-picker)
-windowrulev2 = pin, class:(hyprland-share-picker)
-windowrulev2 = center, title:class:(hyprland-share-picker)
-windowrulev2 = size 600 400,class:(hyprland-share-picker)
+windowrule = float, class:(hyprland-share-picker)
+windowrule = pin, class:(hyprland-share-picker)
+windowrule = center, title:class:(hyprland-share-picker)
+windowrule = size 600 400,class:(hyprland-share-picker)
 
 # General floating
-windowrulev2 = float,class:(dotfiles-floating)
-windowrulev2 = size 1000 700,class:(dotfiles-floating)
-windowrulev2 = center,class:(dotfiles-floating)
-windowrulev2 = pin, class:(dotfiles-floating)
+windowrule = float,class:(dotfiles-floating)
+windowrule = size 1000 700,class:(dotfiles-floating)
+windowrule = center,class:(dotfiles-floating)
+windowrule = pin, class:(dotfiles-floating)
 
 # Floating for Ghostty
-windowrulev2 = float,class:(ml4w.dotfiles.floating)
-windowrulev2 = size 1000 700,class:(ml4w.dotfiles.floating)
-windowrulev2 = center,class:(ml4w.dotfiles.floating)
-windowrulev2 = pin, class:(ml4w.dotfiles.floating)
+windowrule = float,class:(ml4w.dotfiles.floating)
+windowrule = size 1000 700,class:(ml4w.dotfiles.floating)
+windowrule = center,class:(ml4w.dotfiles.floating)
+windowrule = pin, class:(ml4w.dotfiles.floating)
 
 # XDG Desktop Portal
 env = XDG_CURRENT_DESKTOP,Hyprland


### PR DESCRIPTION
Breaking changes:

    windowrule v1 syntax is gone. windowrule now behaves like windowrulev2, deprecating the windowrulev2 keyword
