### PR TITLE
add windowrule for idleinhibit

### DIFF
--- a/share/dotfiles/.config/hypr/conf/windowrules/default.conf
+++ b/share/dotfiles/.config/hypr/conf/windowrules/default.conf
@@ -14,3 +14,6 @@ windowrule = float, title:^(qalculate-gtk)$
 windowrule = float, title:^(Picture-in-Picture)$
 windowrule = pin, title:^(Picture-in-Picture)$
 windowrule = move 69.5% 4%, title:^(Picture-in-Picture)$
+
+# idleinhibit
+windowrule = idleinhibit fullscreen,class:([window])

--- a/share/dotfiles/.config/hypr/conf/windowrules/default.conf
+++ b/share/dotfiles/.config/hypr/conf/windowrules/default.conf
@@ -16,4 +16,4 @@ windowrule = pin, title:^(Picture-in-Picture)$
 windowrule = move 69.5% 4%, title:^(Picture-in-Picture)$
 
 # idleinhibit
-windowrule = idleinhibit fullscreen,class:([window])
+windowrule = idleinhibit fullscreen,class:([window]) # Available modes: none, always, focus, fullscreen


### PR DESCRIPTION
This adds a windowrule idleinhibit and this makes it so hypridle will not file when in fullscreen. This is helpful because when you are watching vids or playing games it could lock your screen and this prevents that.
