### PR TITLE
fix: Changes required after upgrading from version 0.47 to 0.48.

### DIFF
--- a/share/dotfiles/.config/hypr/conf/windowrules/default.conf
+++ b/share/dotfiles/.config/hypr/conf/windowrules/default.conf
@@ -1,16 +1,15 @@
 # -----------------------------------------------------
 # Window rules
 # -----------------------------------------------------
-
-windowrule = tile,^(Microsoft-edge)$
-windowrule = tile,^(Brave-browser)$
-windowrule = tile,^(Chromium)$
-windowrule = float,^(pavucontrol)$
-windowrule = float,^(blueman-manager)$
-windowrule = float,^(nm-connection-editor)$
-windowrule = float,^(qalculate-gtk)$
-
+ 
+windowrulev2 = tile, class:^(Microsoft-edge)$
+windowrulev2 = tile, class:^(Brave-browser)$
+windowrulev2 = tile, class:^(Chromium)$
+windowrulev2 = float, class:^(pavucontrol)$
+windowrulev2 = float, class:^(blueman-manager)$
+windowrulev2 = float, class:^(nm-connection-editor)$
+windowrulev2 = float, class:^(qalculate-gtk)$
+ 
 # Browser Picture in Picture
 windowrulev2 = float, title:^(Picture-in-Picture)$
 windowrulev2 = pin, title:^(Picture-in-Picture)$
-windowrulev2 = move 69.5% 4%, title:^(Picture-in-Picture)$


### PR DESCRIPTION
After updating the Hyprland version from version 0.47 to 0.48, the old configuration stopped working, making this adjustment necessary. As I have already made the correction, I decided to share it.