### PR TITLE
Fix multiple instances of Waybar after resuming from suspend

### DIFF
--- a/share/dotfiles/.config/hypr/scripts/wallpaper.sh
+++ b/share/dotfiles/.config/hypr/scripts/wallpaper.sh
@@ -122,7 +122,8 @@ fi
 # Reload Waybar
 # -----------------------------------------------------
 
-killall -SIGUSR2 waybar
+sleep 2
+$HOME/.config/waybar/launch.sh &
 
 # -----------------------------------------------------
 # Reload nwg-dock-hyprland


### PR DESCRIPTION
Replaced SIGUSR2 to prevent multiple Waybar instances from starting after suspend. The signal-based reload was causing duplicate bars on resume.