### PR TITLE
add arch audio pkg dependencies

### DIFF
--- a/share/packages/arch/options/other.sh
+++ b/share/packages/arch/options/other.sh
@@ -1,4 +1,7 @@
 optdepends=(
     "gnome-calculator"
     "loupe"
+    "pipewire"
+    "wireplumber"
+    "pipewire-pulse"
 )


### PR DESCRIPTION
Fn keys on fresh arch install could not toggle volume. After installing these package dependencies it helped resolved the issue.