### PR TITLE
fix: Updated XF86Tools binding for ML4W Settings app

### DIFF
--- a/share/dotfiles/.config/hypr/conf/keybindings/default.conf
+++ b/share/dotfiles/.config/hypr/conf/keybindings/default.conf
@@ -117,7 +117,7 @@ bind = , XF86AudioPrev, exec, playerctl previous                                
 bind = , XF86AudioMicMute, exec, pactl set-source-mute @DEFAULT_SOURCE@ toggle                                                                               # Toggle microphone
 bind = , XF86Calculator, exec, ~/.config/ml4w/settings/calculator.sh                                                                                         # Open calculator
 bind = , XF86Lock, exec, hyprlock                                                                                                                            # Open screenlock
-bind = , XF86Tools, exec, $(cat ~/.config/ml4w/settings/terminal.sh) --class dotfiles-floating -e ~/.config/ml4w/apps/ML4W_Dotfiles_Settings-x86_64.AppImage # Open ML4W Dotfiles Settings app
+bind = , XF86Tools, exec, flatpak run com.ml4w.settings                                                                                                      # Open ML4W Dotfiles Settings app
 
 bind = , code:238, exec, brightnessctl -d smc::kbd_backlight s +10
 bind = , code:237, exec, brightnessctl -d smc::kbd_backlight s 10-


### PR DESCRIPTION
The previous config used unsupported shell substitution ($(...)) and referenced a deprecated AppImage path. This caused Hyprlang 0.6.2+ to throw a config parse error. This update replaces it with the Flatpak version of ML4W Settings, restoring compatibility.

Edit: Hyprlang has since been updated to resolve the conflict with shell substitution. However, I've decided to leave this pull request open for now as it still addresses the use of the deprecated AppImage, which is no longer present in the default ML4W dotfiles install.