### PR TITLE
custom/updates in waybar config: Auto hide and refresh after running installupdates.sh

### DIFF
--- a/share/dotfiles/.config/ml4w/scripts/installupdates.sh
+++ b/share/dotfiles/.config/ml4w/scripts/installupdates.sh
@@ -96,5 +96,7 @@ echo ":: Update complete"
 echo
 echo
 
+pkill -RTMIN+1 waybar
+
 echo "Press [ENTER] to close."
 read

--- a/share/dotfiles/.config/ml4w/scripts/updates.sh
+++ b/share/dotfiles/.config/ml4w/scripts/updates.sh
@@ -75,8 +75,10 @@ if [ "$updates" -gt $threshhold_red ]; then
     css_class="red"
 fi
 
-if [ "$updates" -gt $threshhold_green ]; then
-    printf '{"text": "%s", "alt": "%s", "tooltip": "Click to update your system", "class": "%s"}' "$updates" "$updates" "$css_class"
-else
-    printf '{"text": "0", "alt": "0", "tooltip": "No updates available", "class": "green"}'
+if [ "$updates" != 0 ]; then
+    if [ "$updates" -gt $threshhold_green ]; then
+        printf '{"text": "%s", "alt": "%s", "tooltip": "Click to update your system", "class": "%s"}' "$updates" "$updates" "$css_class"
+    else
+        printf '{"text": "0", "alt": "0", "tooltip": "No updates available", "class": "green"}'
+    fi
 fi

--- a/share/dotfiles/.config/waybar/modules.json
+++ b/share/dotfiles/.config/waybar/modules.json
@@ -88,6 +88,8 @@
     "return-type": "json",
     "exec": "~/.config/ml4w/scripts/updates.sh",
     "interval": 1800,
+    "signal": 1,
+    "hide-empty-text": true,
     "on-click": "~/.config/ml4w/settings/installupdates.sh",
     "on-click-right": "~/.config/ml4w/settings/software.sh"
   },


### PR DESCRIPTION
I have added auto-hide to custom/updates when there are no packages to reduce amount of space taken up on the waybar.
I have also added `pkill -RTMIN+1 waybar`  to the end of the installupdates.sh file so that the exec of this module is rerun immediately to refresh the output of the module.

One concern with this however is that this last change needs to set a signal and i chose to use signal 1. None of the other modules in this config use signals so this should be fine, however if a user wants to add their own module to this file and wants to use the signal 1 it may(?) cause a problem