### PR TITLE
docs: make setup links compatible with Fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can find the Hyprland Installation instructions here: https://wiki.hyprland.
 Recommended is to install the Hyprland Desktop Profile from archinstall first.
 
 ```shell
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-arch.sh)"
+bash -c "$(curl -s https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-arch.sh)"
 ```
 
 
@@ -56,7 +56,7 @@ Please rebuild all packages to ensure that you get the latest commit.
 Tested on Fedora Workstation 41 and 42.
 
 ```shell
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-fedora.sh)"
+bash -c "$(curl -s https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-fedora.sh)"
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ You can find the Hyprland Installation instructions here: https://wiki.hyprland.
 Recommended is to install the Hyprland Desktop Profile from archinstall first.
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-arch.sh)
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-arch.sh)"
 ```
+
 
 YouTube Video https://youtu.be/sVFnd5LAYAc
 
@@ -55,7 +56,7 @@ Please rebuild all packages to ensure that you get the latest commit.
 Tested on Fedora Workstation 41 and 42.
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-fedora.sh)
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-fedora.sh)"
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
as you know, fish is not posix-compliant, so it doesn't support bash syntax like bash <(curl -L ...)

so i used bash -c to tell fish to run the command with bash. this way, it won't break the setup script.

the final command is:

for arch 

bash -c "$(curl -fsSL https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-arch.sh)"

for fedora 

bash -c "$(curl -fsSL https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/setup-fedora.sh)"

yeah, this doesn't break anything. i tested the arch script, and it works fine.