### PR TITLE
Update wallpaper.sh in the INSTALLATION Script.

### DIFF
--- a/lib/install/dotfiles/wallpaper.sh
+++ b/lib/install/dotfiles/wallpaper.sh
@@ -3,17 +3,34 @@
 # ------------------------------------------------------
 _writeLogHeader "Wallpaper"
 
-if [ -d $HOME/.config/waypaper ]; then
-    _writeLogTerminal 0 "Waypaper configuration exists"
-    rm -rf $ml4w_directory/$version/.config/waypaper
+if [ -d "$HOME/.config/waypaper" ]; then
+    _writeLogTerminal 0 "Waypaper configuration exists."
+    echo "A new configuration is available and may be important for compatibility or features."
+    read -p "Do you want to overwrite your existing Waypaper configuration with the new one? [y/N]: " confirm
+    case "$confirm" in
+        [yY][eE][sS]|[yY])
+            _writeLogTerminal 1 "User chose to overwrite Waypaper configuration."
+            rm -rf "$HOME/.config/waypaper"
+            cp -r "$ml4w_directory/$version/.config/waypaper" "$HOME/.config/waypaper"
+            _writeLogTerminal 1 "Waypaper configuration overwritten with the new version."
+            ;;
+        *)
+            _writeLogTerminal 0 "Keeping existing Waypaper configuration. New version not applied."
+            ;;
+    esac
 else
-    if [ -d ~/wallpaper/ ]; then
-        _writeLogTerminal 0 "$HOME/wallpaper folder already exists."
-    else
-        _writeHeader "Wallpapers"
-        mkdir -p $HOME/wallpaper
-        cp $wallpaper_directory/* ~/wallpaper/
-        _writeLogTerminal 1 "Default wallpapers installed successfully."
-    fi
+    _writeLogTerminal 0 "No existing Waypaper configuration found."
+    cp -r "$ml4w_directory/$version/.config/waypaper" "$HOME/.config/waypaper"
+    _writeLogTerminal 1 "Waypaper configuration installed."
 fi
+
+if [ -d "$HOME/wallpaper/" ]; then
+    _writeLogTerminal 0 "$HOME/wallpaper folder already exists."
+else
+    _writeLogHeader "Wallpapers"
+    mkdir -p "$HOME/wallpaper"
+    cp "$wallpaper_directory"/* "$HOME/wallpaper/"
+    _writeLogTerminal 1 "Default wallpapers installed successfully."
+fi
+
 echo


### PR DESCRIPTION
Recently, I updated to the latest 2.9.8.6 version of the dotfiles from a much older 2.9.1.1 version. On the very first boot, I ran into an issue: the waybar was gone, and there were no colors in the rofi menus, e.t.c. These exact problems are also faced by many  who have either updated to the latest version from a far older one or recently moved to the ml4w dotfiles. These are some #issues to name:
1. #944
2. #938
3. #925
4. #906
5. #899
I dug deep into the problem, leading to this conclusion.

## **THERE IS A PROBLEM IN THE INSTALLATION FILES**

Specifically in this file: ```main-branch/lib/install/dotfiles/wallpaper.sh```

```
# ------------------------------------------------------
# Install wallpapers
# ------------------------------------------------------
_writeLogHeader "Wallpaper"

if [ -d $HOME/.config/waypaper ]; then
    _writeLogTerminal 0 "Waypaper configuration exists"
    rm -rf $ml4w_directory/$version/.config/waypaper
else
    if [ -d ~/wallpaper/ ]; then
        _writeLogTerminal 0 "$HOME/wallpaper folder already exists."
    else
        _writeHeader "Wallpapers"
        mkdir -p $HOME/wallpaper
        cp $wallpaper_directory/* ~/wallpaper/
        _writeLogTerminal 1 "Default wallpapers installed successfully."
    fi
fi
echo
```

So, at line:8 the script deletes the waypaper ml4w config to be installed if there already exsists a waypaper folder in the home/.config directory. 

**wallpaper.sh** script is called in the **ml4w-hyprland-setup.sh** script at line:135 during the install process. This means that if the user is using Waypaper already, the new Waypaper config is not installed, and it falls back to the user config. 

This is a big problem because in the new updated waypaper/config.ini file, which is in the version 2.9.8.3 and later contains the post_command function that gives the selected wallpaper to the $HOME/.config/hypr/scripts/wallpaper.sh as an argument thus matugen and wallust are executed and the color pallets are generated. This worked for me, at least.  

Here is the waypaper/config.ini 
```
[Settings]
language = en
folder = ~/wallpaper
wallpaper = ~/wallpaper/default.jpg
backend = hyprpaper
monitors = All
fill = fill
sort = name
color = #ffffff
subfolders = False
show_hidden = False
show_gifs_only = False
post_command = ~/.config/hypr/scripts/wallpaper.sh "$wallpaper"
number_of_columns = 3
swww_transition_type = any
swww_transition_step = 90
swww_transition_angle = 0
swww_transition_duration = 2
swww_transition_fps = 60
use_xdg_state = False

```

So, we can also see in my install logs that the new waypaper config is not copied. line:18
```
# ------------------------------------------------------
# Kitty
# ------------------------------------------------------

20250527140700 MESSAGE The script has detected a kitty folder in your ~/.config folder.
20250527140700 MESSAGE You can keep or replace it with the latest version of ML4W Dotfiles 2.9.8.6.
20250527140703 MESSAGE ML4W Kitty configuration will be installed

# ------------------------------------------------------
# Neovim
# ------------------------------------------------------


# ------------------------------------------------------
# Wallpaper
# ------------------------------------------------------

20250527140705 MESSAGE Waypaper configuration exists

# ------------------------------------------------------
# Protect
# ------------------------------------------------------

20250527140705 MESSAGE Checking for directory ~/.config/alacritty
20250527140705 MESSAGE Checking for directory ~/.config/bashrc
20250527140705 MESSAGE Checking for directory ~/.config/dunst
20250527140705 MESSAGE Checking for directory ~/.config/eww
20250527140705 MESSAGE Checking for directory ~/.config/fastfetch
20250527140705 MESSAGE Checking for directory ~/.config/gtk-3.0
20250527140705 MESSAGE Checking for directory ~/.config/gtk-4.0
20250527140705 MESSAGE Checking for directory ~/.config/hypr
20250527140705 MESSAGE Checking for directory ~/.config/kitty
20250527140705 MESSAGE Checking for directory ~/.config/matugen
20250527140705 MESSAGE Checking for directory ~/.config/ml4w
20250527140705 MESSAGE Checking for directory ~/.config/nvim
20250527140705 MESSAGE Checking for directory ~/.config/nwg-dock-hyprland
20250527140705 MESSAGE Checking for directory ~/.config/ohmyposh
20250527140705 MESSAGE Checking for directory ~/.config/picom
20250527140705 MESSAGE Checking for directory ~/.config/qt6ct
20250527140705 MESSAGE Checking for directory ~/.config/qtile
20250527140705 MESSAGE Checking for directory ~/.config/rofi
20250527140705 MESSAGE Checking for directory ~/.config/screenshots
20250527140705 MESSAGE Checking for directory ~/.config/starship
20250527140705 MESSAGE Checking for directory ~/.config/swappy
20250527140705 MESSAGE Checking for directory ~/.config/swaync
20250527140705 MESSAGE Checking for directory ~/.config/vim
20250527140705 MESSAGE Checking for directory ~/.config/wal
20250527140705 MESSAGE Checking for directory ~/.config/wallpapers
20250527140705 MESSAGE Checking for directory ~/.config/wallust
20250527140705 MESSAGE Checking for directory ~/.config/waybar
20250527140705 MESSAGE Checking for directory ~/.config/wlogout
20250527140705 MESSAGE Checking for directory ~/.config/xsettingsd
20250527140705 MESSAGE Checking for directory ~/.config/zshrc

# ------------------------------------------------------
# Copy
# ------------------------------------------------------

20250527140714 SUCCESS Copy started
sending incremental file list
./
.Xresources
.bashrc
.gtkrc-2.0
.zshrc
.config/
.config/bashrc/
.config/bashrc/00-init
.config/bashrc/10-aliases
.config/bashrc/20-customization
.config/bashrc/30-autostart
.config/dunst/
.config/dunst/dunstrc
.config/fastfetch/
.config/fastfetch/config.jsonc
.config/gtk-3.0/
.config/gtk-3.0/colors.css
.config/gtk-3.0/gtk.css
.config/gtk-3.0/settings.ini
.config/gtk-4.0/
.config/gtk-4.0/colors.css
.config/gtk-4.0/gtk.css
.config/gtk-4.0/settings.ini
.config/hypr/
.config/hypr/colors.conf
.config/hypr/hypridle.conf
.config/hypr/hyprland.conf
.config/hypr/hyprlock.conf
.config/hypr/hyprpaper.conf
.config/hypr/conf/
.config/hypr/conf/animation.conf
.config/hypr/conf/autostart.conf
.config/hypr/conf/cursor.conf
.config/hypr/conf/custom.conf
.config/hypr/conf/decoration.conf
.config/hypr/conf/environment.conf
.config/hypr/conf/keybinding.conf
.config/hypr/conf/keyboard.conf
.config/hypr/conf/layout.conf
.config/hypr/conf/misc.conf
.config/hypr/conf/ml4w.conf
.config/hypr/conf/monitor.conf
.config/hypr/conf/restorevariations.sh
.config/hypr/conf/window.conf
.config/hypr/conf/windowrule.conf
.config/hypr/conf/workspace.conf
.config/hypr/conf/animations/
.config/hypr/conf/animations/animations-classic.conf
.config/hypr/conf/animations/animations-dynamic.conf
.config/hypr/conf/animations/animations-end4.conf
.config/hypr/conf/animations/animations-fast.conf
.config/hypr/conf/animations/animations-high.conf
.config/hypr/conf/animations/animations-moving.conf
.config/hypr/conf/animations/default.conf
.config/hypr/conf/animations/disabled.conf
.config/hypr/conf/animations/standard.conf
.config/hypr/conf/decorations/
.config/hypr/conf/decorations/default.conf
.config/hypr/conf/decorations/no-rounding-more-blur.conf
.config/hypr/conf/decorations/no-rounding.conf
.config/hypr/conf/decorations/rounding-all-blur-no-shadows.conf
.config/hypr/conf/decorations/rounding-all-blur.conf
.config/hypr/conf/decorations/rounding-more-blur.conf
.config/hypr/conf/decorations/rounding.conf
.config/hypr/conf/environments/
.config/hypr/conf/environments/default.conf
.config/hypr/conf/environments/kvm.conf
.config/hypr/conf/environments/nvidia.conf
.config/hypr/conf/keybindings/
.config/hypr/conf/keybindings/default.conf
.config/hypr/conf/keybindings/fr.conf
.config/hypr/conf/layouts/
.config/hypr/conf/layouts/default.conf
.config/hypr/conf/layouts/laptop.conf
.config/hypr/conf/monitors/
.config/hypr/conf/monitors/1366x768.conf
.config/hypr/conf/monitors/1440x1080.conf
.config/hypr/conf/monitors/1600x900.conf
.config/hypr/conf/monitors/1920x1080.conf
.config/hypr/conf/monitors/1920x1200.conf
.config/hypr/conf/monitors/2560x1440.conf
.config/hypr/conf/monitors/2560x1440@120.conf
.config/hypr/conf/monitors/2560x1440@120x125.conf
.config/hypr/conf/monitors/3440x1440.conf
.config/hypr/conf/monitors/default.conf
.config/hypr/conf/monitors/highres.conf
.config/hypr/conf/monitors/nwg-displays.conf
.config/hypr/conf/windowrules/
.config/hypr/conf/windowrules/default.conf
.config/hypr/conf/windows/
.config/hypr/conf/windows/border-1-reverse.conf
.config/hypr/conf/windows/border-1.conf
.config/hypr/conf/windows/border-2-reverse.conf
.config/hypr/conf/windows/border-2.conf
.config/hypr/conf/windows/border-3-reverse.conf
.config/hypr/conf/windows/border-3.conf
.config/hypr/conf/windows/border-4-reverse.conf
.config/hypr/conf/windows/border-4.conf
.config/hypr/conf/windows/default.conf
.config/hypr/conf/windows/no-border-more-gaps.conf
.config/hypr/conf/windows/no-border.conf
.config/hypr/conf/workspaces/
.config/hypr/conf/workspaces/default.conf
.config/hypr/effects/wallpaper/
.config/hypr/effects/wallpaper/blackwhite
.config/hypr/effects/wallpaper/blackwhite-blur
.config/hypr/effects/wallpaper/blackwhite-brightness40
.config/hypr/effects/wallpaper/blackwhite-brightness60
.config/hypr/effects/wallpaper/blackwhite-brightness80
.config/hypr/effects/wallpaper/blur1
.config/hypr/effects/wallpaper/blur1-brightness40
.config/hypr/effects/wallpaper/blur1-brightness60
.config/hypr/effects/wallpaper/blur1-brightness80
.config/hypr/effects/wallpaper/blur2
.config/hypr/effects/wallpaper/negate
.config/hypr/effects/wallpaper/negate-brightness40
.config/hypr/effects/wallpaper/negate-brightness60
.config/hypr/effects/wallpaper/negate-brightness80
.config/hypr/scripts/
.config/hypr/scripts/cleanup.sh
.config/hypr/scripts/disabledm.sh
.config/hypr/scripts/gamemode.sh
.config/hypr/scripts/gtk.sh
.config/hypr/scripts/hypridle.sh
.config/hypr/scripts/hyprshade.sh
.config/hypr/scripts/init-wallpaper-engine.sh
.config/hypr/scripts/keybindings.sh
.config/hypr/scripts/loadconfig.sh
.config/hypr/scripts/moveTo.sh
.config/hypr/scripts/power.sh
.config/hypr/scripts/restart-hypridle.sh
.config/hypr/scripts/screenshot.sh
.config/hypr/scripts/systeminfo.sh
.config/hypr/scripts/toggle-animations.sh
.config/hypr/scripts/toggleallfloat.sh
.config/hypr/scripts/wallpaper-automation.sh
.config/hypr/scripts/wallpaper-cache.sh
.config/hypr/scripts/wallpaper-effects.sh
.config/hypr/scripts/wallpaper-restore.sh
.config/hypr/scripts/wallpaper.sh
.config/hypr/scripts/xdg.sh
.config/hypr/shaders/
.config/hypr/shaders/blue-light-filter-25.glsl
.config/hypr/shaders/blue-light-filter-50.glsl
.config/hypr/shaders/blue-light-filter-75.glsl
.config/hypr/shaders/invert-colors.glsl
.config/kitty/
.config/kitty/kitty.conf
.config/matugen/
.config/matugen/config.toml
.config/matugen/templates/
.config/matugen/templates/colors.css
.config/matugen/templates/gtk-colors.css
.config/matugen/templates/hyprland-colors.conf
.config/matugen/templates/kitty-colors.conf
.config/matugen/templates/ohmyposh-colors.json
.config/matugen/templates/ohmyposh.json
.config/matugen/templates/pywalfox-colors.json
.config/matugen/templates/rofi-colors.rasi
.config/matugen/templates/sequences
.config/ml4w/
.config/ml4w/assets/
.config/ml4w/assets/blank.png
.config/ml4w/login/
.config/ml4w/login/issue
.config/ml4w/scripts/
.config/ml4w/scripts/cliphist.sh
.config/ml4w/scripts/figlet.sh
.config/ml4w/scripts/installupdates.sh
.config/ml4w/scripts/ml4w-autostart.sh
.config/ml4w/scripts/nm-applet.sh
.config/ml4w/scripts/sddm-wallpaper.sh
.config/ml4w/scripts/shell.sh
.config/ml4w/scripts/thunarterminal.sh
.config/ml4w/scripts/updates.sh
.config/ml4w/scripts/wlogout.sh
.config/ml4w/scripts/arch/
.config/ml4w/scripts/arch/cleanup.sh
.config/ml4w/scripts/arch/installprinters.sh
.config/ml4w/scripts/arch/installtimeshift.sh
.config/ml4w/scripts/arch/lid-improvements.sh
.config/ml4w/scripts/arch/pacman.sh
.config/ml4w/scripts/arch/snapshot.sh
.config/ml4w/scripts/arch/unlock-pacman.sh
.config/ml4w/settings/
.config/ml4w/settings/ai.sh
.config/ml4w/settings/aur.sh
.config/ml4w/settings/blur.sh
.config/ml4w/settings/browser.sh
.config/ml4w/settings/calculator.sh
.config/ml4w/settings/calendar.sh
.config/ml4w/settings/dotfiles-folder.sh
.config/ml4w/settings/dunst_position.sh
.config/ml4w/settings/editor.sh
.config/ml4w/settings/email.sh
.config/ml4w/settings/emojipicker.sh
.config/ml4w/settings/eww-monitor.sh
.config/ml4w/settings/filemanager.sh
.config/ml4w/settings/hyprpaper.tpl
.config/ml4w/settings/hyprpicker.sh
.config/ml4w/settings/hyprshade.sh
.config/ml4w/settings/installupdates.sh
.config/ml4w/settings/kitty-cursor-trail.conf
.config/ml4w/settings/ml4w-sidebar.sh
.config/ml4w/settings/networkmanager.sh
.config/ml4w/settings/printer-drivers.sh
.config/ml4w/settings/rofi-border-radius.rasi
.config/ml4w/settings/rofi-border.rasi
.config/ml4w/settings/rofi-font.rasi
.config/ml4w/settings/rofi_bordersize.sh
.config/ml4w/settings/screenshot-editor.sh
.config/ml4w/settings/screenshot-filename.sh
.config/ml4w/settings/screenshot-folder.sh
.config/ml4w/settings/software.sh
.config/ml4w/settings/system-monitor.sh
.config/ml4w/settings/terminal.sh
.config/ml4w/settings/wallpaper-automation.sh
.config/ml4w/settings/wallpaper-effect.sh
.config/ml4w/settings/wallpaper-engine.sh
.config/ml4w/settings/wallpaper-folder.sh
.config/ml4w/settings/waybar-quicklinks.json
.config/ml4w/settings/waybar_appmenu.sh
.config/ml4w/settings/waybar_backlight.sh
.config/ml4w/settings/waybar_chatgpt.sh
.config/ml4w/settings/waybar_custom_timedateformat.sh
.config/ml4w/settings/waybar_dateformat.sh
.config/ml4w/settings/waybar_network.sh
.config/ml4w/settings/waybar_quicklinks.sh
.config/ml4w/settings/waybar_screenlock.sh
.config/ml4w/settings/waybar_settings.sh
.config/ml4w/settings/waybar_systray.sh
.config/ml4w/settings/waybar_taskbar.sh
.config/ml4w/settings/waybar_timeformat.sh
.config/ml4w/settings/waybar_timezone.sh
.config/ml4w/settings/waybar_toggle.sh
.config/ml4w/settings/waybar_window.sh
.config/ml4w/settings/waybar_workspaces.sh
.config/ml4w/settings/wlogout-parameters.sh
.config/ml4w/settings/sddm/
.config/ml4w/settings/sddm/theme.tpl
.config/ml4w/tpl/
.config/ml4w/tpl/.zshrc
.config/ml4w/version/
.config/ml4w/version/compare.sh
.config/ml4w/version/library.sh
.config/ml4w/version/name
.config/ml4w/version/update.sh
.config/nvim/
.config/nvim/init.vim
.config/nwg-dock-hyprland/
.config/nwg-dock-hyprland/launch.sh
.config/nwg-dock-hyprland/style-dark.css
.config/nwg-dock-hyprland/style-light.css
.config/ohmyposh/
.config/ohmyposh/EDM115-newline.omp.json
.config/ohmyposh/zen.toml
.config/qt6ct/
.config/qt6ct/qt6ct.conf
.config/rofi/
.config/rofi/backup
.config/rofi/config-cliphist.rasi
.config/rofi/config-compact.rasi
.config/rofi/config-hyprshade.rasi
.config/rofi/config-old.rasi
.config/rofi/config-screenshot.rasi
.config/rofi/config-short.rasi
.config/rofi/config-themes.rasi
.config/rofi/config.rasi
.config/swaync/
.config/swaync/config.json
.config/swaync/style.css
.config/vim/
.config/vim/.vimrc
.config/wal/templates/
.config/wal/templates/colors-hyprland.conf
.config/wal/templates/colors-rofi-pywal.rasi
.config/wal/templates/colors-waybar.css
.config/wal/templates/colors-wlogout.css
.config/wallust/
.config/wallust/wallust.toml
.config/wallust/templates/
.config/wallust/templates/kitty-colors.conf
.config/waybar/
.config/waybar/launch.sh
.config/waybar/modules.json
.config/waybar/themeswitcher.sh
.config/waybar/toggle.sh
.config/waybar/themes/assets/
.config/waybar/themes/assets/ai-icon-20.png
.config/waybar/themes/assets/ai-icon.png
.config/waybar/themes/assets/hyprland-icon-20.png
.config/waybar/themes/assets/hyprland-icon.png
.config/waybar/themes/assets/ml4w-icon-20.png
.config/waybar/themes/assets/ml4w-icon-black.svg
.config/waybar/themes/assets/ml4w-icon-dark.png
.config/waybar/themes/assets/ml4w-icon-white.svg
.config/waybar/themes/assets/ml4w-icon.png
.config/waybar/themes/assets/ml4w-icon.svg
.config/waybar/themes/assets/openai-black.svg
.config/waybar/themes/assets/openai-white.svg
.config/waybar/themes/assets/openai.svg
.config/waybar/themes/default/
.config/waybar/themes/default/config
.config/waybar/themes/default/config.sh
.config/waybar/themes/default/style.css
.config/waybar/themes/ml4w-blur/
.config/waybar/themes/ml4w-blur/config
.config/waybar/themes/ml4w-blur/style.css
.config/waybar/themes/ml4w-blur/black/
.config/waybar/themes/ml4w-blur/black/config.sh
.config/waybar/themes/ml4w-blur/black/style.css
.config/waybar/themes/ml4w-blur/dark/
.config/waybar/themes/ml4w-blur/dark/config.sh
.config/waybar/themes/ml4w-blur/dark/style.css
.config/waybar/themes/ml4w-blur/light/
.config/waybar/themes/ml4w-blur/light/config.sh
.config/waybar/themes/ml4w-blur/light/style.css
.config/waybar/themes/ml4w-blur/white/
.config/waybar/themes/ml4w-blur/white/config.sh
.config/waybar/themes/ml4w-blur/white/style.css
.config/waybar/themes/ml4w-minimal/
.config/waybar/themes/ml4w-minimal/config
.config/waybar/themes/ml4w-minimal/config.sh
.config/waybar/themes/ml4w-minimal/style.css
.config/waybar/themes/ml4w-modern/
.config/waybar/themes/ml4w-modern/config
.config/waybar/themes/ml4w-modern/style.css
.config/waybar/themes/ml4w-modern/black/
.config/waybar/themes/ml4w-modern/black/config.sh
.config/waybar/themes/ml4w-modern/black/style.css
.config/waybar/themes/ml4w-modern/colored/
.config/waybar/themes/ml4w-modern/colored/config.sh
.config/waybar/themes/ml4w-modern/colored/style.css
.config/waybar/themes/ml4w-modern/dark/
.config/waybar/themes/ml4w-modern/dark/config.sh
.config/waybar/themes/ml4w-modern/dark/style.css
.config/waybar/themes/ml4w-modern/light/
.config/waybar/themes/ml4w-modern/light/config.sh
.config/waybar/themes/ml4w-modern/light/style.css
.config/waybar/themes/ml4w-modern/white/
.config/waybar/themes/ml4w-modern/white/config.sh
.config/waybar/themes/ml4w-modern/white/style.css
.config/waybar/themes/ml4w/
.config/waybar/themes/ml4w/config
.config/waybar/themes/ml4w/style.css
.config/waybar/themes/ml4w/black/
.config/waybar/themes/ml4w/black/config.sh
.config/waybar/themes/ml4w/black/style.css
.config/waybar/themes/ml4w/dark/
.config/waybar/themes/ml4w/dark/config.sh
.config/waybar/themes/ml4w/dark/style.css
.config/waybar/themes/ml4w/light/
.config/waybar/themes/ml4w/light/config.sh
.config/waybar/themes/ml4w/light/style.css
.config/waybar/themes/ml4w/white/
.config/waybar/themes/ml4w/white/config.sh
.config/waybar/themes/ml4w/white/style.css
.config/waybar/themes/starter/
.config/waybar/themes/starter/config
.config/waybar/themes/starter/config.sh
.config/waybar/themes/starter/modules.json
.config/waybar/themes/starter/style.css
.config/wlogout/
.config/wlogout/README.txt
.config/wlogout/layout
.config/wlogout/noise.png
.config/wlogout/style.css
.config/wlogout/icons/
.config/wlogout/icons/hibernate.png
.config/wlogout/icons/lock.png
.config/wlogout/icons/logout.png
.config/wlogout/icons/reboot.png
.config/wlogout/icons/shutdown.png
.config/wlogout/icons/suspend.png
.config/xsettingsd/
.config/xsettingsd/xsettingsd.conf
.config/zshrc/
.config/zshrc/00-init
.config/zshrc/20-customization
.config/zshrc/25-aliases
.config/zshrc/30-autostart

sent 586.88K bytes  received 6.30K bytes  1.19M bytes/sec
total size is 564.22K  speedup is 0.95
20250527140714 SUCCESS All files from /home/ghost/.ml4w-hyprland/2.9.8.6/ to ~/dotfiles/ copied.

```

This is the bug that has caused me 3 days of havoc.

# FIX:

It can be fixed easily be just modifying the file to either ask the user whether he wants to replace the file or the default option that it overwrites the existing config.

```
# ------------------------------------------------------
# Install wallpapers
# ------------------------------------------------------
_writeLogHeader "Wallpaper"

if [ -d "$HOME/.config/waypaper" ]; then
    _writeLogTerminal 0 "Waypaper configuration exists."
    echo "A new configuration is available and may be important for compatibility or features."
    read -p "Do you want to overwrite your existing Waypaper configuration with the new one? [y/N]: " confirm
    case "$confirm" in
        [yY][eE][sS]|[yY])
            _writeLogTerminal 1 "User chose to overwrite Waypaper configuration."
            rm -rf "$HOME/.config/waypaper"
            cp -r "$ml4w_directory/$version/.config/waypaper" "$HOME/.config/"
            _writeLogTerminal 1 "Waypaper configuration overwritten with the new version."
            ;;
        *)
            _writeLogTerminal 0 "Keeping existing Waypaper configuration. New version not applied."
            ;;
    esac
else
    _writeLogTerminal 0 "No existing Waypaper configuration found."
    cp -r "$ml4w_directory/$version/.config/waypaper" "$HOME/.config/"
    _writeLogTerminal 1 "Waypaper configuration installed."
fi

if [ -d "$HOME/wallpaper/" ]; then
    _writeLogTerminal 0 "$HOME/wallpaper folder already exists."
else
    _writeLogHeader "Wallpapers"
    mkdir -p "$HOME/wallpaper"
    cp "$wallpaper_directory"/* "$HOME/wallpaper/"
    _writeLogTerminal 1 "Default wallpapers installed successfully."
fi

echo

```

## Summary of logic:

- If Waypaper config exists → prompt user → overwrite if yes, leave it if no.
    
- If it doesn’t exist → simply copy from the `ml4w_directory`.
    
- `$ml4w_directory/$version/.config/waypaper` is **never deleted** now.