### PR TITLE
[FEATURE] Add One-Touch Screenshot Functionality (#836)

### DIFF
--- a/share/dotfiles/.config/hypr/conf/keybindings/default.conf
+++ b/share/dotfiles/.config/hypr/conf/keybindings/default.conf
@@ -48,6 +48,7 @@ bind = $mainMod SHIFT, A, exec, $HYPRSCRIPTS/toggle-animations.sh               
 bind = $mainMod, PRINT, exec, $HYPRSCRIPTS/screenshot.sh                                  # Take a screenshot
 bind = $mainMod SHIFT, S, exec, $HYPRSCRIPTS/screenshot.sh                                # Take a screenshot
 bind = $mainMod ALT, F, exec, $HYPRSCRIPTS/screenshot.sh --instant                        # Take an instant full-screen screenshot
+bind = $mainMod ALT, S, exec, $HYPRSCRIPTS/screenshot.sh --instant-area                   # Take an instant area screenshot
 bind = $mainMod CTRL, Q, exec, ~/.config/ml4w/scripts/wlogout.sh                          # Start wlogout
 bind = $mainMod SHIFT, W, exec, waypaper --random                                         # Change the wallpaper
 bind = $mainMod CTRL, W, exec, waypaper                                                   # Open wallpaper selector

--- a/share/dotfiles/.config/hypr/conf/keybindings/default.conf
+++ b/share/dotfiles/.config/hypr/conf/keybindings/default.conf
@@ -47,6 +47,7 @@ bind = $mainMod CTRL, R, exec, hyprctl reload                                   
 bind = $mainMod SHIFT, A, exec, $HYPRSCRIPTS/toggle-animations.sh                         # Toggle animations
 bind = $mainMod, PRINT, exec, $HYPRSCRIPTS/screenshot.sh                                  # Take a screenshot
 bind = $mainMod SHIFT, S, exec, $HYPRSCRIPTS/screenshot.sh                                # Take a screenshot
+bind = $mainMod ALT, F, exec, $HYPRSCRIPTS/screenshot.sh --instant                        # Take an instant full-screen screenshot
 bind = $mainMod CTRL, Q, exec, ~/.config/ml4w/scripts/wlogout.sh                          # Start wlogout
 bind = $mainMod SHIFT, W, exec, waypaper --random                                         # Change the wallpaper
 bind = $mainMod CTRL, W, exec, waypaper                                                   # Open wallpaper selector

--- a/share/dotfiles/.config/hypr/scripts/screenshot.sh
+++ b/share/dotfiles/.config/hypr/scripts/screenshot.sh
@@ -32,6 +32,18 @@ export GRIMBLAST_EDITOR="$(cat ~/.config/ml4w/settings/screenshot-editor.sh)"
 # bind = SUPER ALT, p, exec, grimblast save output
 # bind = SUPER CTRL, p, exec, grimblast save screen
 
+# Quick instant mode: full screen
+take_instant_full() {
+    grim "$NAME" && notify-send -t 1000 "Screenshot saved to $screenshot_folder/$NAME"
+    [[ -f "$HOME/$NAME" && -d "$screenshot_folder" && -w "$screenshot_folder" ]] && mv "$HOME/$NAME" "$screenshot_folder/"
+}
+
+# Handle instant flags
+if [[ "$1" == "--instant" ]]; then
+    take_instant_full
+    exit 0
+fi
+
 # Options
 option_1="Immediate"
 option_2="Delayed"

--- a/share/dotfiles/.config/hypr/scripts/screenshot.sh
+++ b/share/dotfiles/.config/hypr/scripts/screenshot.sh
@@ -38,9 +38,35 @@ take_instant_full() {
     [[ -f "$HOME/$NAME" && -d "$screenshot_folder" && -w "$screenshot_folder" ]] && mv "$HOME/$NAME" "$screenshot_folder/"
 }
 
+# Quick instant mode: area selection
+take_instant_area() {
+    local pid_picker region
+
+    # freeze screen for region selection
+    hyprpicker -r -z &
+    pid_picker=$!
+    trap 'kill "$pid_picker" 2>/dev/null' EXIT
+    sleep 0.1
+
+    # user selects region; kill picker on cancel
+    region=$(slurp -b "#00000080" -c "#888888ff" -w 1) || exit 0
+    [[ -z "$region" ]] && exit 0
+
+    # unfreeze screen
+    kill "$pid_picker" 2>/dev/null
+    trap - EXIT
+
+    # capture and notify
+    grim -g "$region" "$NAME" && notify-send -t 1000 "Screenshot saved to $screenshot_folder/$NAME"
+    [[ -f "$HOME/$NAME" && -d "$screenshot_folder" && -w "$screenshot_folder" ]] && mv "$HOME/$NAME" "$screenshot_folder/"
+}
+
 # Handle instant flags
 if [[ "$1" == "--instant" ]]; then
     take_instant_full
+    exit 0
+elif [[ "$1" == "--instant-area" ]]; then
+    take_instant_area
     exit 0
 fi
 


### PR DESCRIPTION
**What it does**
This PR adds support for **instant screenshots** with two new functions in `screenshot.sh`:

* `take_instant_full()` — instantly captures the entire screen using `grim`
* `take_instant_area()` — lets you select an area and captures it immediately after selection

These new functions are designed for speed and do not open any menus or dialogs.

**Keybindings added** (`keybindings/default.conf`):

* `SUPER + CTRL + F` → Instant full-screen screenshot (`--instant`)
* `SUPER + ALT + S` → Instant area screenshot (`--instant-area`)

**Why we use `grim` instead of `grimblast`**
To make the screenshots truly **instant**, we bypass `grimblast` and directly call `grim`, which is a lower-level tool without extra logic, menus, or delays. This gives faster execution and better control.

**Why `hyprpicker` freezes the screen in area mode**
In `take_instant_area()`, we use `hyprpicker` to let the user select an area. Hyprpicker captures a frozen image of the screen so the user can make a clean, static selection without interference from moving windows or animations. This behavior is intentional and expected. it’s similar to how most GUI screenshot tools work when selecting an area.

**This is especially helpful when taking screenshots from classes or videos**, where content is constantly changing and precise timing matters.


**Tested on**
✅ **Arch** and ✅ **Fedora**

* Verified full and area screenshot functions
* Confirmed files save correctly to `$screenshot_folder`
* Notifications work as expected
* Existing interactive Rofi modes remain unaffected

**Closes #836** — Adds "one-touch" screenshot keybindings and performance improvements with grim.
