### PR TITLE
fix(waybar): prevent duplicate launches with flock

### DIFF
--- a/share/dotfiles/.config/waybar/launch.sh
+++ b/share/dotfiles/.config/waybar/launch.sh
@@ -6,10 +6,17 @@
 #            /___/
 #
 # -----------------------------------------------------
+# Prevent duplicate launches: only the first parallel
+# invocation proceeds; all others exit immediately.
+# -----------------------------------------------------
+exec 200>/tmp/waybar-launch.lock
+flock -n 200 || exit 0
+
+# -----------------------------------------------------
 # Quit all running waybar instances
 # -----------------------------------------------------
-killall waybar
-pkill waybar
+killall waybar || true
+pkill waybar || true
 sleep 0.5
 
 # -----------------------------------------------------
@@ -54,3 +61,7 @@ if [ ! -f $HOME/.config/ml4w/settings/waybar-disabled ]; then
 else
     echo ":: Waybar disabled"
 fi
+
+# Explicitly release the lock (optional) -> flock releases on exit
+flock -u 200
+exec 200>&-


### PR DESCRIPTION
This PR ensures that only the first concurrent invocation of launch.sh ever runs its logic, preventing multiple back-to-back killall/pkill cycles and duplicate restarts of Waybar. We achieve this by adding a non-blocking flock at the top of the script and explicitly releasing it at the end.

Background / Debug Logs (anonymized):
Without this lock, two session hooks (wallpaper.sh and xdg.sh) both invoke launch.sh nearly simultaneously, leading to two separate kill/start sequences:

This happened to me after a clean install of CachyOs and a clean install of Arch-Linux today:

=== Waybar launch at <timestamp> ===
User: <user>
Shell: /bin/zsh
PPID: <pid1>
Parent process info:
PID PPID CMD
<pid1> <ppid0> /bin/bash … wallpaper.sh …
Full process tree:
systemd(1)───…───wallpaper.sh───launch.sh

=== Waybar launch at <timestamp> ===
User: <user>
Shell: /bin/zsh
PPID: <pid2>
Parent process info:
PID PPID CMD
<pid2> <ppid0> /bin/bash … xdg.sh …
Full process tree:
systemd(1)───…───xdg.sh───launch.sh

Each run did:

    killall waybar

    pkill waybar

    Start a new waybar &

Resulting in two rapid restarts of Waybar.

Changes:

    Add flock lock (non-blocking) at top of launch.sh:
    exec 200>/tmp/waybar-launch.lock
    flock -n 200 || exit 0

    Keep killall/pkill so that on first invocation we still cleanly restart Waybar.

    Optional unlock at end for clarity: (which is not really needed)
    flock -u 200
    exec 200>&-

With this, the second concurrent call to launch.sh will immediately exit, avoiding any duplicate kill/start behavior.