### PR TITLE
docs: hide footer in showcase

### DIFF
--- a/docs/showcases/index.md
+++ b/docs/showcases/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+footer: false
 ---
 
 <script setup>


### PR DESCRIPTION
we don't need footer in showcase side, so we can hide it with `footer: false`