### PR TITLE
Fix: update ml4w-update alias

### DIFF
--- a/share/dotfiles/.config/bashrc/10-aliases
+++ b/share/dotfiles/.config/bashrc/10-aliases
@@ -31,7 +31,7 @@ alias ml4w-options='ml4w-hyprland-setup -m options'
 alias ml4w-diagnosis='~/.config/hypr/scripts/diagnosis.sh'
 alias ml4w-hyprland-diagnosis='~/.config/hypr/scripts/diagnosis.sh'
 alias ml4w-qtile-diagnosis='~/.config/ml4w/qtile/scripts/diagnosis.sh'
-alias ml4w-update='~/.config/ml4w/update.sh'
+alias ml4w-update='~/.config/ml4w/scripts/installupdates.sh'
 
 # -----------------------------------------------------
 # Window Managers

--- a/share/dotfiles/.config/zshrc/25-aliases
+++ b/share/dotfiles/.config/zshrc/25-aliases
@@ -31,7 +31,7 @@ alias ml4w-options='ml4w-hyprland-setup -m options'
 alias ml4w-diagnosis='~/.config/hypr/scripts/diagnosis.sh'
 alias ml4w-hyprland-diagnosis='~/.config/hypr/scripts/diagnosis.sh'
 alias ml4w-qtile-diagnosis='~/.config/ml4w/qtile/scripts/diagnosis.sh'
-alias ml4w-update='~/.config/ml4w/update.sh'
+alias ml4w-update='~/.config/ml4w/scripts/installupdates.sh'
 
 # -----------------------------------------------------
 # Window Managers


### PR DESCRIPTION
Update `ml4w-update` alias on both zsh and bash alias script config files, to match correct script path.