### PR TITLE
docs: fix nwg-displays install guide on fedora

### DIFF
--- a/docs/configuration/monitor-setup.md
+++ b/docs/configuration/monitor-setup.md
@@ -31,7 +31,10 @@ sudo pacman -S nwg-displays
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
-sudo dnf install nwg-displays
+sudo dnf install python-build python-installer python-wheel python-setuptools
+git clone https://github.com/nwg-piotr/nwg-displays ~/nwg-displays
+cd ~/nwg-displays && chmod +x install.sh
+sudo ./install.sh
 ```
 :::
 


### PR DESCRIPTION
`nwg-displays` is not in the official fedora package repository.  
yes, someone is maintaining a package here: [https://copr.fedorainfracloud.org/coprs/aeiro/nwg-shell/](https://copr.fedorainfracloud.org/coprs/aeiro/nwg-shell/),  
but when i tried installing it, i encountered a conflict with `python(abi)`.  
it might be an issue with my fedora container.

rather than doing that, we can prefer to install it manually by following the official guide.  
you can check: [https://github.com/nwg-piotr/nwg-displays/blob/master/install.sh](https://github.com/nwg-piotr/nwg-displays/blob/master/install.sh)
