### PR TITLE
fix: mistyped app launchur

### DIFF
--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -37,7 +37,7 @@ The Dotfiles will be installed into the folder `~/.mydotfiles` with symbolic lin
 Install the following dependencies on a minimal Arch Linux installation
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -S hyprland vim wget curl kitty wofi firefox flatpak
+sudo pacman -S hyprland vim wget curl kitty rofi firefox flatpak
 
 ```
 Reboot and then start Hyprland with 


### PR DESCRIPTION
### Description

i don't know if it was intentional from your side or just a mistype. as far as i know, we are using rofi, right?

i guess this is a mistake. if i'm wrong, you can close this pr.

edit: at the dependencies side, there is a package listed as rofi-wayland. if we put a different package in both places, there will be a conflict.
did we change that to rofi-wayland or is it fine as rofi? wdyt?

```sh
❯ sudo pacman -S rofi-wayland
resolving dependencies...
looking for conflicting packages...
:: rofi-wayland-1.7.9.1-1.1 and rofi-1.7.9.1-1.1 are in conflict. Remove rofi? [y/N]
```

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [x] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->
