### PR TITLE
Update default.conf xwayland wndow rules

### DIFF
--- a/dotfiles/.config/hypr/conf/windowrules/default.conf
+++ b/dotfiles/.config/hypr/conf/windowrules/default.conf
@@ -17,3 +17,13 @@ windowrule = move 69.5% 4%, title:^(Picture-in-Picture)$
 
 # idleinhibit
 windowrule = idleinhibit fullscreen,class:([window]) # Available modes: none, always, focus, fullscreen
+
+#xwayland related rules
+# when moving objects in resolve a large border is produced 
+# This rule prevents that and serves as a template for any problematic xwayland apps
+windowrule = noblur, class:^(\bresolve\b)$, xwayland:1
+# This is a general rule for xwayland apps but can have other consequences 
+# for one user it impacted EMACs so it's disabled by default 
+# It's here as a reference or for quick triage of xwayland ap
+#windowrule = noblur, xwayland:1
+


### PR DESCRIPTION

### Description

Xwayland apps like Davinci - Resolve often have huge borders b/c of  Wayland blur   This fixes Resovle and serves as a template
 
### Changes
- [x] Improved <!-- Optimized existing functionality -->
- 
### Context

Xwayland apps don't always behave well in Hyprland when BLUR is enabled 

 ### How Has This Been Tested?

 - [X] Tested on Arch Linux/Based Distro.
- [X] Tested on NixOS 

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce new warnings.
