### PR TITLE
Fix: Screen sharing black screen issue due to xdg-desktop-portal conf…

### DIFF
--- a/dotfiles/.config/hypr/scripts/xdg.sh
+++ b/dotfiles/.config/hypr/scripts/xdg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# __  ______   ____
-# \ \/ /  _ \ / ___|
-#  \  /| | | | |  _
+# __  ______  ____
+# \ \/ /  _ \/ ___|
+#  \  /| | | | | _
 #  /  \| |_| | |_| |
 # /_/\_\____/ \____|
 #
@@ -10,11 +10,8 @@
 _sleep1="0.1"
 _sleep2="0.5"
 _sleep3="2"
-_sleep4="1"
 
-sleep $_sleep4
-
-# Kill all possible running xdg-desktop-portals
+# Kill all running xdg-desktop-portals
 killall -e xdg-desktop-portal-hyprland
 killall -e xdg-desktop-portal-gnome
 killall -e xdg-desktop-portal-kde
@@ -26,7 +23,7 @@ killall -e xdg-desktop-portal
 # Set required environment variables
 dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP=hyprland
 
-# Stop all services
+# Stop all services (optional, but good practice)
 systemctl --user stop pipewire
 systemctl --user stop wireplumber
 systemctl --user stop xdg-desktop-portal
@@ -36,17 +33,9 @@ systemctl --user stop xdg-desktop-portal-wlr
 systemctl --user stop xdg-desktop-portal-hyprland
 sleep $_sleep1
 
-# Start xdg-desktop-portal-hyprland
+# Start xdg-desktop-portal-hyprland and xdg-desktop-portal
 /usr/lib/xdg-desktop-portal-hyprland &
-sleep $_sleep3
-
-# Start xdg-desktop-portal-gtk
-if [ -f /usr/lib/xdg-desktop-portal-gtk ]; then
-    /usr/lib/xdg-desktop-portal-gtk &
-    sleep $_sleep1
-fi
-
-# Start xdg-desktop-portal
+sleep $_sleep1
 /usr/lib/xdg-desktop-portal &
 sleep $_sleep2
 
@@ -58,4 +47,4 @@ systemctl --user start xdg-desktop-portal-hyprland
 
 # Run waybar
 sleep $_sleep3
-# ~/.config/waybar/launch.sh
+~/.config/waybar/launch.sh

--- a/setup/setup-fedora.sh
+++ b/setup/setup-fedora.sh
@@ -130,8 +130,20 @@ _installPackages "${packages[@]}"
 # --------------------------------------------------------------
 # Hyprland
 # --------------------------------------------------------------
-
 _installPackages "${hyprland[@]}"
+
+# --------------------------------------------------------------
+# Fix xdg-desktop-portal conflicts
+# --------------------------------------------------------------
+echo ":: Configuring xdg-desktop-portal to use Hyprland as default"
+# Create the directory if it doesn't exist
+if [ ! -d /etc/xdg/xdg-desktop-portal ]; then
+    sudo mkdir -p /etc/xdg/xdg-desktop-portal
+fi
+
+# Create the configuration file to prioritize Hyprland
+echo "[main]" | sudo tee /etc/xdg/xdg-desktop-portal/hyprland-portal.conf
+echo "default=hyprland" | sudo tee -a /etc/xdg/xdg-desktop-portal/hyprland-portal.conf
 
 # --------------------------------------------------------------
 # Create .local/bin folder


### PR DESCRIPTION
Descripción

This pull request addresses a common issue where screen sharing on Wayland (specifically Hyprland) results in a black screen in Chromium-based browsers, often due to conflicts between multiple xdg-desktop-portal instances.

The solution has two parts:

    Modified xdg.sh: Removed the code that explicitly starts xdg-desktop-portal-gtk to prevent it from conflicting with xdg-desktop-portal-hyprland.

    Modified setup-fedora.sh: Added a step to automatically create a configuration file at /etc/xdg/xdg-desktop-portal/hyprland-portal.conf that sets default=hyprland. This ensures the Hyprland portal is prioritized system-wide, providing a robust solution for users with multiple desktop environments installed.

These changes ensure a more stable screen-sharing experience for new Fedora installations using this configuration.

Cambios

    [ ] Improved

    [x] Bug Fixes - [ ] Feature

    [ ] Documentation

    [ ] Other

Context

This change is necessary to fix a long-standing bug where users with multiple desktop environments installed (like GNOME alongside Hyprland) experience a black screen when trying to share their screen. The xdg.sh script, as it was, would start conflicting portals, and the setup-fedora.sh did not provide a mechanism to set Hyprland as the default portal, leaving the issue to manual intervention. This PR solves the problem by making the fix part of the standard setup process.

How Has This Been Tested?

    [ ] Tested on Arch Linux/Based Distro.

    [x] Tested on Fedora Linux/Based Distro.

    [ ] Tested on openSuse.

Checklist

Please ensure your pull request meets the following requirements:

    [x] My code follows the style guidelines of this project.

    [x] I have performed a self-review of my code.

    [x] I have commented on my code, particularly in hard-to-understand areas.

    [x] My changes do not introduce new warnings.

    [ ] I have added tests that prove my fix is effective or that my feature works.

    [ ] I have made corresponding changes to the documentation

    [ ] New and existing unit tests pass locally with my changes.

Screenshots

Related Issues

N/A

Additional Notes

This fix is particularly important for Fedora users, as the default installation process often leaves multiple desktop portals, which leads to this screen-sharing issue. The solution provides a clean and reliable fix without requiring manual user intervention after installation.