### PR TITLE
Replace dependency “rofi-wayland” with “rofi” for better Wayland and IME support

### DIFF
--- a/docs/getting-started/dependencies.md
+++ b/docs/getting-started/dependencies.md
@@ -50,7 +50,7 @@ cliphist
 nwg-look
 qt6ct
 waybar
-rofi-wayland
+rofi
 polkit-gnome
 zsh
 zsh-completions

--- a/setup/pkgs.sh
+++ b/setup/pkgs.sh
@@ -25,7 +25,7 @@ apps=(
     "vlc"
     "nwg-dock-hyprland"
     "waybar"
-    "rofi-wayland"
+    "rofi"
     "nwg-look"
     "pavucontrol"
     "neovim"


### PR DESCRIPTION
### Description

This pull request replaces the dependency “rofi-wayland” with “rofi” since “rofi” now has native Wayland support. Additionally, “rofi” provides better compatibility with input method frameworks such as fcitx, making it a more versatile choice compared to “rofi-wayland”.

### Changes
- [x] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

This change is necessary because “rofi” has gained native Wayland support, making “rofi-wayland” redundant. Moreover, “rofi” works better with IME frameworks (like fcitx), which solves compatibility issues encountered with “rofi-wayland”.

### How Has This Been Tested?

- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->

### Additional Notes

No further notes.