### PR TITLE
fix: sync database first before -Qum and checkupdates Fixes #1235

### DIFF
--- a/dotfiles/.config/ml4w/scripts/updates.sh
+++ b/dotfiles/.config/ml4w/scripts/updates.sh
@@ -55,6 +55,8 @@ if [[ $(_checkCommandExists "pacman") == 0 ]]; then
 
     check_lock_files
 
+    $aur_helper -Sy --quiet
+
     updates_aur=$($aur_helper -Qum | wc -l)
     updates_pacman=$(checkupdates | wc -l)
     updates=$((updates_aur+updates_pacman))


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This pull request adds/updates/fixes [describe the main goal or feature].

### Changes
- [x] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->
`$aur_helper -Qum | wc -l` will still show 0 if the local database is not updated/synced first. 

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->

- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->

### Related Issues

Fixes #1235 

### Additional Notes

Just a one line change that I think will make the updates count better.

