### PR TITLE
Bugfix for `checkupdates`

### DIFF
--- a/setup/setup-arch.sh
+++ b/setup/setup-arch.sh
@@ -34,6 +34,7 @@ packages=(
     "polkit-gnome"
     "hyprshade"
     "grimblast-git"
+    "pacman-contrib"
     "loupe"
     "power-profiles-daemon"
     # Apps


### PR DESCRIPTION
To use `checkupdates`, we need the `pacman-contrib`.
- `pacman-contrib` was previously installed as a dependency of `checkupdates-with-aur` and contains the `checkupdates` application.
