### PR TITLE
Added opacity change in gamemode.sh

### DIFF
--- a/dotfiles/.config/hypr/scripts/gamemode.sh
+++ b/dotfiles/.config/hypr/scripts/gamemode.sh
@@ -37,6 +37,9 @@ else
     keyword general:gaps_in 0;\
     keyword general:gaps_out 0;\
     keyword general:border_size 1;\
+    keyword decoration:active_opacity 1;\
+    keyword decoration:inactive_opacity 1;\
+    keyword decoration:fullscreen_opacity 1;\
     keyword decoration:rounding 0"
   touch $HOME/.config/ml4w/settings/gamemode-enabled
   notify-send "Gamemode activated" "Animations and blur disabled"


### PR DESCRIPTION
### Description

This pull request addresses a visual issue within the gamemode.sh script where background elements remained faintly visible (transparent) behind fullscreen applications, especially games.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

When running the existing gamemode.sh script, many users (particularly those with transparent backgrounds/widgets) would still see a subtle background bleed-through, even for active, fullscreen windows.
The fix is simply adding the following three lines to the hyprctl --batch command in the activation block to aggressively force full opacity (1.0) across all possible states:

### How Has This Been Tested?

- [x ] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes.

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->
unknown

### Additional Notes

This is a clean, minimal fix that targets the specific Hyprland keywords responsible for fullscreen transparency, significantly improving the 'gamemode' experience without affecting other non-gaming functionality.
