### PR TITLE
Show keyboard layout in hyprlock input placeholder

### DIFF
--- a/dotfiles/.config/hypr/hyprlock.conf
+++ b/dotfiles/.config/hypr/hyprlock.conf
@@ -33,9 +33,9 @@ input-field {
     font_family = Fira Semibold
     outer_color = $on_primary
     outline_thickness = 3
-    fade_on_empty = true
+    fade_on_empty = false # Changed to false since the keyboard layout should always be shown.
     fade_timeout = 1000 # Milliseconds before fade_on_empty is triggered.
-    placeholder_text = <i>Input Password...</i> # Text rendered in the input box when it's empty.
+    placeholder_text = <span foreground="white">Layout: $LAYOUT</span> # Current keyboard layout rendered in the input box when it's empty.
     hide_input = false
     rounding = 10 # -1 means complete rounding (circle/oval)
     check_color = $primary


### PR DESCRIPTION
### Description

This pull request improves the Hyprlock user experience by ensuring the active keyboard layout is always visible before entering the password. This is essential for users who regularly switch between multiple layouts.

### Changes
- [x] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

Previously, Hyprlock hid the placeholder text after a short timeout, making it unclear which keyboard layout was active before typing a password.
This caused authentication mistakes and unnecessary retries for users with multiple layouts (e.g., DE/EN/HR...).
The update ensures the layout is always visible, improving consistency and usability.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

(Not required, as this is a configuration change and visual behavior is self-explanatory.)

### Related Issues

None.

### Additional Notes

This change is fully backward-compatible.
