### PR TITLE
docs: fix one missing command for installation

### DIFF
--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -29,7 +29,7 @@ https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/hyprland-dotfiles
 https://raw.githubusercontent.com/mylinuxforwork/dotfiles/main/hyprland-dotfiles.dotinst
 ```
 
-Setup scripts to install the required dependencies are included for Arch, Fedora and openSuse Tumbleweed.
+Setup scripts to install the required dependencies are included for Arch, Fedora and openSuse Tumbleweed. 
 
 The installation of dependencies can take between 5 to 15 minutes depending on your internet connection and system performance.
 
@@ -40,7 +40,7 @@ For other distros, please install <a href="/dotfiles/getting-started/dependencie
 The Dotfiles will be installed into the folder `~/.mydotfiles` with symbolic links into `~/.config`.
 
 ::: info RECOMMENDATION
-I recommend to install a base Hyprland system before installing the ML4W Hyprland Dotfiles. Then you have a stable starting point and can test Hyprland on your system before. Hyprland is complex, under ongoing development and requires additional components.
+I recommend to install a base Hyprland system before installing the ML4W Hyprland Dotfiles. Then you have a stable starting point and can test Hyprland on your system before. Hyprland is complex, under ongoing development and requires additional components. 
 
 On Arch Linux you can also install the Hyprland Desktop Profile first.
 
@@ -55,7 +55,7 @@ Install the following dependencies on a minimal Arch Linux installation
 sudo pacman -S hyprland vim kitty firefox flatpak
 
 ```
-Reboot and then start Hyprland with
+Reboot and then start Hyprland with 
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
 Hyprland
@@ -64,9 +64,9 @@ Hyprland
 Open Firefox, open the Dotfiles Installer Homepage and follow the installation instructions.
 
 ::: warning AUR not supported anymore
-Please note that the AUR packages for the ML4W Dotfiles for Hyprland are not supported anymore. Please uninstall the package with
+Please note that the AUR packages for the ML4W Dotfiles for Hyprland are not supported anymore. Please uninstall the package with 
 
-```sh
+```sh 
 yay -R ml4w-dotfiles # Main Release
 yay -R ml4w-dotfiles-git # Rolling Release
 ```
@@ -74,21 +74,21 @@ yay -R ml4w-dotfiles-git # Rolling Release
 
 ## Installation with GNU stow
 
-The installation without the Dotfiles Installer is possible but not recommended (especially not for beginners).
+The installation without the Dotfiles Installer is possible but not recommended (especially not for beginners). 
 
 > [!NOTE]
 > Please create a backup from your current configuration. This guide is under developement
 
 The manual installation requires stow. Please install it on your system e.g., on Arch with
 
-```sh
+```sh 
 sudo pacman -S stow
 ```
 
 Please follow the following steps:
 
-```sh
-mkdir -p ~/Projects # Create a projects folder
+```sh 
+mkdir -p ~/Projects # Create a projects folder 
 cd ~/Projects #cd into the Projects directory
 git clone --depth 1 https://github.com/mylinuxforwork/dotfiles # Rolling Release
 cd ~/Projects/dotfiles/setup # cd into the setup folder
@@ -96,7 +96,7 @@ cd ~/Projects/dotfiles/setup # cd into the setup folder
 ```
 Create symlinks into your home folder
 
-```sh
+```sh 
 cd ~/Projects/dotfiles
 stow dotfiles
 ```


### PR DESCRIPTION
### Description

Well, one `cd` is missing for installation in this [`page`](https://mylinuxforwork.github.io/dotfiles/getting-started/install)

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [x] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

Well the changes are neesary, beacuse in the nest step, the guide tells us to clone the `dotfiles` repo! and then it requests to `cd` into the setup folder. But there is no command for `cd` into the `Projects` directory.

### How Has This Been Tested?

Not required

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.


### Additional Notes

Thanks for creating this beautiful dotfiles. I suggest for `curl` command declaration in the installation tutorial. Have a nice day!