### PR TITLE
Add new feature `OS age` in fastfetch config

### DIFF
--- a/dotfiles/.config/fastfetch/config.jsonc
+++ b/dotfiles/.config/fastfetch/config.jsonc
@@ -29,7 +29,7 @@
           "type": "command",
           "key": "│ {#33}󱦟 OS Age  {#keys}|",
           "keyColor": "magenta",
-          "text": "birth_install=$(stat -c %W /); current=$(date +%s); time_progression=$((current - birth_install)); days_difference=$((time_progression / 86400)); echo $days_difference days"
+          "text": "echo $(( ($(date +%s) - $(stat -c %W /)) / 86400 )) days"
         },
         {
             "key": "│ {#34}󰅐 uptime  {#keys}│",


### PR DESCRIPTION
### Description

Well, I added a cool feature in fastfetch config. Which shows the `OS age` . 

### Changes
- [x] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

This is little bit not stylish but still it is good.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.


### Additional Notes

I hope it's good, if any problems found then please request a review! Have a nice day!
