### PR TITLE
fix: swaync glass theme close button position (#1355)

### DIFF
--- a/dotfiles/.config/swaync/themes/glass/notifications.css
+++ b/dotfiles/.config/swaync/themes/glass/notifications.css
@@ -125,7 +125,7 @@
   border-radius: 7px;
   color: @text;
   background-color: alpha(#fff, 0.5);
-  margin: 16px 24px;
+  margin: 0px;
   padding: 2px;
 }
 


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This pull request fixes the positioning of the close button in SwayNC notifications when using the `glass` theme. Note that the button was previously rendering outside the notification box.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->
The close button in the `glass` theme had excessive margins (`16px 24px`), which pushed it outside the notification container. This PR adjusts the margin to `0px` to correctly align it inside the notification box, ensuring consistency with the `modern` theme and fixing the reported visual bug.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [ ] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

*Note: Verified via code inspection and comparison with other working themes. Visual verification required on a Wayland/Hyprland environment.*

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->
N/A

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->
Fixes #1355 

### Additional Notes

<!-- Add any other context, technical details, or considerations you'd like to share. -->
The fix aligns the CSS configuration of the `glass` theme with the `modern` theme regarding the close button margins. Verified that `npm run docs:build` passes without regression.