### PR TITLE
Fix broken border and color bleed in os age module

### DIFF
--- a/dotfiles/.config/fastfetch/config.jsonc
+++ b/dotfiles/.config/fastfetch/config.jsonc
@@ -27,9 +27,9 @@
         },
         {
           "type": "command",
-          "key": "│ {#33}󱦟 os age  {#keys}|",
+          "key": "│ {#33}󱦟 os age  {#keys}│",
           "keyColor": "magenta",
-          "text": "echo $(( ($(date +%s) - $(stat -c %W /)) / 86400 )) days"
+          "text": "printf \"\\e[0m%s days\\e[0m\" \"$(( ($(date +%s) - $(stat -c %W /)) / 86400 ))\""
         },
         {
             "key": "│ {#34}󰅐 uptime  {#keys}│",


### PR DESCRIPTION
### Description

This pull request fixes a visual rendering issue in the `os age` fastfetch module where the box border was broken and colors leaked into subsequent lines.

### Changes
- [x] Bug Fixes

### Context

The `os age` command module used an ASCII `|` instead of the box-drawing character `│`, which caused the right border to appear disconnected.  
Additionally, the command output did not reset ANSI colors, resulting in color bleed into the following modules.

This change corrects both issues while keeping the configuration otherwise unchanged.

### How Has This Been Tested?

- [x] Tested on Arch Linux/Based Distro.

Verified by running `fastfetch` in a terminal with a Nerd Font enabled and confirming that:
- the box borders render correctly
- no color bleeding occurs

### Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes do not introduce new warnings.

### Screenshots

N/A

### Related Issues

N/A

### Additional Notes

The diff is intentionally minimal and only addresses the rendering bugs in the `os age` module.
