### PR TITLE
fix(wallpaper.sh): 

### DIFF
--- a/dotfiles/.config/hypr/scripts/wallpaper.sh
+++ b/dotfiles/.config/hypr/scripts/wallpaper.sh
@@ -100,7 +100,7 @@ _writeLog "Wallpaper Filename: $wallpaperfilename"
 # Wallpaper Effects
 # -----------------------------------------------------
 
-if [ -f $wallpapereffect ]; then
+if [ -f "$wallpapereffect" ]; then
     effect=$(cat "$wallpapereffect")
     if [ ! "$effect" == "off" ]; then
         used_wallpaper="$generatedversions/$effect-$wallpaperfilename"


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This pull request fixes the wallpaper.sh script where there is a space in the wallpaper's filename.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [X] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->
The wallpaper.sh script that update colorscheme when the wallpaper changed, didn't work when the wallpaper contains a space in his filename.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [X] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->
#1380 

