### PR TITLE
Improves the Keybinding parsing logic

### DIFF
--- a/dotfiles/.config/hypr/scripts/keybindings.sh
+++ b/dotfiles/.config/hypr/scripts/keybindings.sh
@@ -23,21 +23,111 @@ launcher=$(cat $HOME/.config/ml4w/settings/launcher)
 echo "Reading from: $config_file"
 
 keybinds=$(awk -F'[=#]' '
-    $1 ~ /^bind/ {
-        # Replace the string "$mainMod" with "SUPER" (for the super key)
-        gsub(/\$mainMod/, "SUPER", $0)
+    function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
 
-        # Remove "bind" and extra spaces, if any, at the beginning of the line
-        gsub(/^bind[[:space:]]*=+[[:space:]]*/, "", $0)
+    BEGIN {
+        # --- replacement table (order matters) ---
+        num_patterns = 0
+        patterns[++num_patterns] = "\\$mainMod_L";              replacements[num_patterns] = "SUPER_L"
+        patterns[++num_patterns] = "\\$mainMod_R";              replacements[num_patterns] = "SUPER_R"
+        patterns[++num_patterns] = "\\$mainMod";                replacements[num_patterns] = "SUPER"
 
-        # Split the keybinding part (e.g., "Mod1,Return") using a comma
-        split($1, kbarr, ",")
+        patterns[++num_patterns] = "bracketleft";               replacements[num_patterns] = "["
+        patterns[++num_patterns] = "bracketright";              replacements[num_patterns] = "]"
+        patterns[++num_patterns] = "comma";                     replacements[num_patterns] = ","
 
-        # Format the keybinding and associated command and prepare for output:
-        # Concatenate the two keybinding keys (e.g., "Mod1" + "Return") and append the command
-        print kbarr[1] "  + " kbarr[2] "\r" $2
+        patterns[++num_patterns] = "XF86AudioRaiseVolume";      replacements[num_patterns] = "FN_VOLUME_UP"
+        patterns[++num_patterns] = "XF86AudioLowerVolume";      replacements[num_patterns] = "FN_VOLUME_DOWN"
+        patterns[++num_patterns] = "XF86AudioMicMute";          replacements[num_patterns] = "FN_MIC_MUTE"
+        patterns[++num_patterns] = "XF86AudioMute";             replacements[num_patterns] = "FN_MUTE"
+        patterns[++num_patterns] = "XF86Sleep";                 replacements[num_patterns] = "FN_SLEEP"
+        patterns[++num_patterns] = "XF86Rfkill";                replacements[num_patterns] = "FN_AIRPLANE_MODE"
+        patterns[++num_patterns] = "XF86AudioPlayPause";        replacements[num_patterns] = "FN_PLAY_PAUSE"
+        patterns[++num_patterns] = "XF86AudioPause";            replacements[num_patterns] = "FN_PAUSE"
+        patterns[++num_patterns] = "XF86AudioPlay";             replacements[num_patterns] = "FN_PLAY"
+        patterns[++num_patterns] = "XF86AudioNext";             replacements[num_patterns] = "FN_NEXT_TRACK"
+        patterns[++num_patterns] = "XF86AudioPrev";             replacements[num_patterns] = "FN_PREVIOUS_TRACK"
+        patterns[++num_patterns] = "XF86AudioStop";             replacements[num_patterns] = "FN_STOP"
+        patterns[++num_patterns] = "XF86Calculator";            replacements[num_patterns] = "FN_CALCUTALOR"
+        patterns[++num_patterns] = "XF86_ScreenSaver";          replacements[num_patterns] = "LOCK_SCREEN"
+        patterns[++num_patterns] = "XF86MonBrightnessUp";       replacements[num_patterns] = "FN_BRIGTHNESS_UP"
+        patterns[++num_patterns] = "XF86MonBrightnessDown";     replacements[num_patterns] = "FN_BRIGTHNESS_DOWN"
+
+        max_combo_len = 0
     }
-' "$config_file")
+
+    # -------- Collect binds --------
+    $1 ~ /^bind[[:alpha:]]*/ {
+        # --- extract trailing comment as description ---
+        desc = ""
+        if (match($0, /#[[:space:]]*(.*)$/, m)) {
+            desc = m[1]
+            gsub(/^[! ]+|[! ]+$/, "", desc)
+            sub(/[ \t]*#.*/, "", $0)
+        }
+
+        gsub(/^bind[[:alpha:]]*[[:space:]]*=+[[:space:]]*/, "", $0)
+        rhs = trim($0)
+        n = split(rhs, a, /[ \t]*,[ \t]*/)
+
+        mods = trim(a[1])
+        key  = (n >= 2 ? trim(a[2]) : "")
+
+        dispatcher = (n >= 3 ? trim(a[3]) : "")
+        params = ""
+
+        for (j = 4; j <= n; j++) {
+            if (length(a[j])) {
+            p = trim(a[j])
+            if (p != "")
+                params = (params ? params ", " : "") p
+        }
+    }
+
+    # apply replacements
+    for (i = 1; i <= num_patterns; i++) {
+        gsub(patterns[i], replacements[i], mods)
+        gsub(patterns[i], replacements[i], key)
+    }
+
+    gsub(/[ \t]+/, " + ", mods)
+    mods = toupper(mods)
+    key  = toupper(key)
+
+    # modifier-only bind fix
+    if (key == mods "_L" || key == mods "_R") {
+        key = ""
+    }
+
+    combo = (mods && key) ? mods " + " key : (key ? key : mods)
+
+    # final description decision
+    if (desc != "")
+        description = desc
+    else if (dispatcher && params)
+        description = dispatcher " " params
+    else
+        description = dispatcher
+
+    lines[NR] = combo
+    descs[NR] = description
+    if (length(combo) > max_combo_len)
+        max_combo_len = length(combo)
+    }
+
+    # -------- Output --------
+    END {
+        for (i in lines) {
+            combo = lines[i]
+            desc  = descs[i]
+
+            if (desc != "")
+                print combo "\r  " desc
+            else
+                print combo
+        }
+    }' "$config_file")
+
 
 sleep 0.2
 


### PR DESCRIPTION
### Description

Adds an extra parsing to the Keybindings script, making some of the keys more readable and allowing "mod only" shortcuts to be properly represented/

### Changes
- [x] Improved
- [x] Bug Fixes
- [ ] Feature
- [ ] Documentation
- [ ] Other

### Context

I use SUPER alone as the Keybind to open the app launcher in my local system.
To achieve that, you need to declare it like this:
bindr = $mainMod, $mainMod_L, exec, $HYPRSCRIPTS/launcher.sh                 # Open application launcher

This breaks the original keybindings window script as it can't parse "bind**r**" and even if it could, it would result in SUPER + SUPER_L as the "key"

The improved version handles those cases and also makes some of the keys more human readable (like common FN keys that are currently named XF86_*)

### How Has This Been Tested?

- [ ] Tested on Arch Linux/Based Distro.
- [x] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

<img width="560" height="712" alt="image" src="https://github.com/user-attachments/assets/d68fc147-f072-4cca-ae55-3ecf99abc772" />

### Related Issues

N/A

### Additional Notes

https://github.com/hyprwm/Hyprland/discussions/2506