### PR TITLE
Centralized notification handler

### DIFF
--- a/dotfiles/.config/hypr/scripts/gamemode.sh
+++ b/dotfiles/.config/hypr/scripts/gamemode.sh
@@ -6,8 +6,15 @@
 # /___/                                     
 # 
 
+
 ml4w_cache_folder="$HOME/.cache/ml4w/hyprland-dotfiles"
 gamemode_monitor="$HOME/.config/hypr/conf/monitors/gamemode.conf"
+
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+APP_NAME="System"
+NOTIFICATION_ICON="joystick"
+
 
 if [ -f $HOME/.config/ml4w/settings/gamemode-enabled ]; then
   if [ -f $ml4w_cache_folder/last_monitor.conf ]; then
@@ -20,7 +27,10 @@ if [ -f $HOME/.config/ml4w/settings/gamemode-enabled ]; then
   fi
   hyprctl reload
   rm $HOME/.config/ml4w/settings/gamemode-enabled
-  notify-send "Gamemode deactivated" "Animations and blur enabled"
+  notify_user --a "${APP_NAME}" \
+            --i "${NOTIFICATION_ICON}" \
+            --s "Gamemode deactivated" \
+            --m "Animations and blur are now enabled."
 else
   if [ -f $gamemode_monitor ]; then
     cat $HOME/.config/hypr/conf/monitor.conf > $ml4w_cache_folder/last_monitor.conf
@@ -42,5 +52,8 @@ else
     keyword decoration:fullscreen_opacity 1;\
     keyword decoration:rounding 0"
   touch $HOME/.config/ml4w/settings/gamemode-enabled
-  notify-send "Gamemode activated" "Animations and blur disabled"
+  notify_user --a "${APP_NAME}" \
+          --i "${NOTIFICATION_ICON}" \
+          --s "Gamemode activated" \
+          --m "Animations and blur are now disabled."
 fi

--- a/dotfiles/.config/hypr/scripts/hyprshade.sh
+++ b/dotfiles/.config/hypr/scripts/hyprshade.sh
@@ -7,6 +7,11 @@
 #        |___/|_|
 #
 
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+APP_NAME="Hyprshade"
+NOTIFICATION_ICON="video-display-symbolic"
+
 # Remove legacy shaders folder
 if [ -d $HOME/.config/hypr/shaders ]; then
     rm -rf $HOME/.config/hypr/shaders
@@ -23,10 +28,16 @@ if [[ "$1" == "rofi" ]]; then
         echo "hyprshade_filter=\"$choice\"" >~/.config/ml4w/settings/hyprshade.sh
         if [ "$choice" == "off" ]; then
             hyprshade off
-            notify-send "Hyprshade deactivated"
+            notify_user --a "${APP_NAME}" \
+                --i "${NOTIFICATION_ICON}" \
+                --s "Hyprshade turned off" \
+                --m ""
             echo ":: hyprshade turned off"
         else
-            notify-send "Changing Hyprshade to $choice" "Toggle shader with SUPER+SHIFT+H"
+            notify_user --a "${APP_NAME}" \
+                --i "${NOTIFICATION_ICON}" \
+                --s "Hyprshade filter" \
+                --m "Changing Hyprshade filter to \"$choice.\" \nToggle shader with SUPER+SHIFT+H"
         fi
     fi
 
@@ -45,10 +56,16 @@ else
         if [ -z $(hyprshade current) ]; then
             echo ":: hyprshade is not running"
             hyprshade on $hyprshade_filter
-            notify-send "Hyprshade activated" "with $(hyprshade current)"
+            notify_user --a "${APP_NAME}" \
+                --i "${NOTIFICATION_ICON}" \
+                --s "Hyprshade activated" \
+                --m "Current filter: $(hyprshade current)."
             echo ":: hyprshade started with $(hyprshade current)"
         else
-            notify-send "Hyprshade deactivated"
+            notify_user --a "${APP_NAME}" \
+                --i "${NOTIFICATION_ICON}" \
+                --s "Hyprshade deactivated" \
+                --m ""
             echo ":: Current hyprshade $(hyprshade current)"
             echo ":: Switching hyprshade off"
             hyprshade off

--- a/dotfiles/.config/hypr/scripts/load-gamemode.sh
+++ b/dotfiles/.config/hypr/scripts/load-gamemode.sh
@@ -6,6 +6,9 @@
 # /___/                                     
 # 
 
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+
 _loadGameMode() {
     hyprctl --batch "\
         keyword animations:enabled 0;\
@@ -19,5 +22,8 @@ _loadGameMode() {
 
 if [ -f $HOME/.config/ml4w/settings/gamemode-enabled ]; then
     _loadGameMode
-    notify-send "Gamemode activated" "Animations and blur disabled"
+    notify_user --a "System" \
+        --i "joystick" \
+        --s "Gamemode activated" \
+        --m "Animations and blur are now disabled."
 fi

--- a/dotfiles/.config/hypr/scripts/restart-hypridle.sh
+++ b/dotfiles/.config/hypr/scripts/restart-hypridle.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
+
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+
 killall hypridle
 sleep 1
 hypridle &
-notify-send "hypridle has been restarted."
+
+notify_user --a "Hypridle" \
+        --s "Hypridle has been restarted." \
+        --m ""

--- a/dotfiles/.config/hypr/scripts/screenshot.sh
+++ b/dotfiles/.config/hypr/scripts/screenshot.sh
@@ -22,6 +22,11 @@ SAVE_FILENAME=$(cat ~/.config/ml4w/settings/screenshot-filename)
 eval screenshot_folder="$SAVE_DIR"
 eval NAME="$SAVE_FILENAME"
 
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+APP_NAME="Screen Capture"
+NOTIFICATION_ICON="camera-photo-symbolic"
+
 # Screenshot Editor
 export GRIMBLAST_EDITOR="$(cat ~/.config/ml4w/settings/screenshot-editor)"
 
@@ -33,7 +38,13 @@ export GRIMBLAST_EDITOR="$(cat ~/.config/ml4w/settings/screenshot-editor)"
 
 # Quick instant mode: full screen
 take_instant_full() {
-    grim "$NAME" && notify-send -t 1000 "Screenshot saved to $screenshot_folder/$NAME"
+    grim "$NAME" && notify_user \
+        --a "${APP_NAME}" \
+        --i "${NOTIFICATION_ICON}" \
+        --s "Screenshot saved" \
+        --m "$screenshot_folder/$NAME" \
+        --t 1000
+
     [[ -f "$HOME/$NAME" && -d "$screenshot_folder" && -w "$screenshot_folder" ]] && mv "$HOME/$NAME" "$screenshot_folder/"
 }
 
@@ -56,7 +67,12 @@ take_instant_area() {
     trap - EXIT
 
     # capture and notify
-    grim -g "$region" "$NAME" && notify-send -t 1000 "Screenshot saved to $screenshot_folder/$NAME"
+    grim -g "$region" "$NAME" && notify_user \
+        --a "${APP_NAME}" \
+        --i "${NOTIFICATION_ICON}" \
+        --s "Screenshot saved" \
+        --m "$screenshot_folder/$NAME" \
+        --t 1000
     [[ -f "$HOME/$NAME" && -d "$screenshot_folder" && -w "$screenshot_folder" ]] && mv "$HOME/$NAME" "$screenshot_folder/"
 }
 
@@ -203,13 +219,23 @@ copy_save_editor_run() {
 
 timer() {
     if [[ $countdown -gt 10 ]]; then
-        notify-send -t 1000 "Taking screenshot in ${countdown} seconds"
+        notify_user \
+            --a "${APP_NAME}" \
+            --i "${NOTIFICATION_ICON}" \
+            --s "Taking screenshot in ${countdown} seconds" \
+            --m "" \
+            --t 1000
         countdown_less_10=$((countdown - 10))
         sleep $countdown_less_10
         countdown=10
     fi
     while [[ $countdown -ne 0 ]]; do
-        notify-send -t 1000 "Taking screenshot in ${countdown} seconds"
+        notify_user \
+            --a "${APP_NAME}" \
+            --i "${NOTIFICATION_ICON}" \
+            --s "Taking screenshot in ${countdown} seconds" \
+            --m "" \
+            --t 1000
         countdown=$((countdown - 1))
         sleep 1
     done

--- a/dotfiles/.config/hypr/scripts/toggleallfloat.sh
+++ b/dotfiles/.config/hypr/scripts/toggleallfloat.sh
@@ -7,4 +7,10 @@
 #
 
 hyprctl dispatch workspaceopt allfloat
-notify-send "Windows on this workspace toggled to floating/tiling"
+
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+
+notify_user \
+        --a "System" \
+        --m "Windows on this workspace toggled to floating/tiling"

--- a/dotfiles/.config/hypr/scripts/wallpaper-automation.sh
+++ b/dotfiles/.config/hypr/scripts/wallpaper-automation.sh
@@ -8,6 +8,11 @@
 
 ml4w_cache_folder="$HOME/.cache/ml4w/hyprland-dotfiles"
 
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+APP_NAME="Waypaper"
+NOTIFICATION_ICON="preferences-desktop-wallpaper-symbolic"
+
 sec=$(cat ~/.config/ml4w/settings/wallpaper-automation.sh)
 _setWallpaperRandomly() {
     waypaper --random
@@ -19,11 +24,17 @@ _setWallpaperRandomly() {
 if [ ! -f $ml4w_cache_folder/wallpaper-automation ]; then
     touch $ml4w_cache_folder/wallpaper-automation
     echo ":: Start wallpaper automation script"
-    notify-send "Wallpaper automation process started" "Wallpaper will be changed every $sec seconds."
+    notify_user \
+        --a "${APP_NAME}" \
+        --i "${NOTIFICATION_ICON}" \
+        --m "Wallpaper automation process started.\nWallpaper will be changed every $sec seconds."
     _setWallpaperRandomly
 else
     rm $ml4w_cache_folder/wallpaper-automation
-    notify-send "Wallpaper automation process stopped."
+    notify_user \
+        --a "${APP_NAME}" \
+        --i "${NOTIFICATION_ICON}" \
+        --m "Wallpaper automation process stopped."
     echo ":: Wallpaper automation script process $wp stopped"
     wp=$(pgrep -f wallpaper-automation.sh)
     kill -KILL $wp

--- a/dotfiles/.config/hypr/scripts/wallpaper-cache.sh
+++ b/dotfiles/.config/hypr/scripts/wallpaper-cache.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
+
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+
 ml4w_cache_folder="$HOME/.cache/ml4w/hyprland-dotfiles"
 generated_versions="$ml4w_cache_folder/wallpaper-generated"
 rm $generated_versions/*
 echo ":: Wallpaper cache cleared"
-notify-send "Wallpaper cache cleared"
+notify_user \
+        --a "System" \
+        --m "Wallpaper cache cleared"

--- a/dotfiles/.config/hypr/scripts/wallpaper-effects.sh
+++ b/dotfiles/.config/hypr/scripts/wallpaper-effects.sh
@@ -6,6 +6,11 @@
 #    \_/\_/  |_|     |_____|_| |_|  \___|\___|\__|___/
 #
 
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+APP_NAME="Waypaper"
+NOTIFICATION_ICON="preferences-desktop-wallpaper-symbolic"
+
 ml4w_cache_folder="$HOME/.cache/ml4w/hyprland-dotfiles"
 
 # Get current wallpaper
@@ -22,7 +27,13 @@ else
     choice=$(echo -e "$options" | rofi -dmenu -replace -config ~/.config/rofi/config-themes.rasi -i -no-show-icons -l 5 -width 30 -p "Hyprshade")
     if [ ! -z $choice ]; then
         echo "$choice" >~/.config/ml4w/settings/wallpaper-effect.sh
-        notify-send "Changing Wallpaper Effect to " "$choice"
+
+        notify_user \
+            --a "${APP_NAME}" \
+            --i "${NOTIFICATION_ICON}" \
+            --s "Wallpaper" \
+            --m "Changing Wallpaper Effect to " "$choice."
+
         waypaper --wallpaper $(cat $cache_file)
     fi
 fi

--- a/dotfiles/.config/hypr/scripts/wallpaper.sh
+++ b/dotfiles/.config/hypr/scripts/wallpaper.sh
@@ -8,6 +8,11 @@
 # Source library.sh
 source $HOME/.config/ml4w/library.sh
 
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+APP_NAME="Waypaper"
+NOTIFICATION_ICON="preferences-desktop-wallpaper-symbolic"
+
 # -----------------------------------------------------
 # Check to use wallpaper cache
 # -----------------------------------------------------
@@ -108,7 +113,13 @@ if [ -f "$wallpapereffect" ]; then
             _writeLog "Use cached wallpaper $effect-$wallpaperfilename"
         else
             _writeLog "Generate new cached wallpaper $effect-$wallpaperfilename with effect $effect"
-            notify-send --replace-id=1 "Using wallpaper effect $effect..." "with image $wallpaperfilename" -h int:value:33
+            
+            notify_user \
+                --a "${APP_NAME}" \
+                --i "${NOTIFICATION_ICON}" \
+                --s "Wallpaper" \
+                --m "Using wallpaper effect $effect\n with image $wallpaperfilename"
+
             source $HOME/.config/hypr/effects/wallpaper/$effect
         fi
         _writeLog "Loading wallpaper $generatedversions/$effect-$wallpaperfilename with effect $effect"
@@ -176,7 +187,6 @@ if [ -f "$generatedversions/blur-$blur-$effect-$wallpaperfilename.png" ] && [ "$
     _writeLog "Use cached wallpaper blur-$blur-$effect-$wallpaperfilename"
 else
     _writeLog "Generate new cached wallpaper blur-$blur-$effect-$wallpaperfilename with blur $blur"
-    # notify-send --replace-id=1 "Generate new blurred version" "with blur $blur" -h int:value:66
     magick "$used_wallpaper" -resize 75% "$blurredwallpaper"
     _writeLog "Resized to 75%"
     if [ ! "$blur" == "0x0" ]; then

--- a/dotfiles/.config/ml4w/listeners/low-bat-notification.sh
+++ b/dotfiles/.config/ml4w/listeners/low-bat-notification.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+APP_NAME="System"
+NOTIFICATION_ICON="battery-low-symbolic"
+
 BAT=$(command ls -d /sys/class/power_supply/BAT* 2>/dev/null | head -n 1)
 if [[ -z "$BAT" ]]; then
     exit 0
@@ -14,10 +19,20 @@ while true; do
 
     if [[ "$STATUS" == "Discharging" ]]; then
         if [[ $CAPACITY -le 15 && $NOTIFIED_15 == false ]]; then
-            notify-send -u critical "Battery Low" "Remaining: ${CAPACITY}%"
+            notify_user \
+                --u "critical" \
+                --a "${APP_NAME}" \
+                --i "${NOTIFICATION_ICON}" \
+                --s "Battery Low" \
+                --m "Remaining: ${CAPACITY}%"
             NOTIFIED_15=true
         elif [[ $CAPACITY -le 20 && $CAPACITY -gt 15 && $NOTIFIED_20 == false ]]; then
-            notify-send -u normal "Battery Low" "Remaining: ${CAPACITY}%"
+            notify_user \
+                --u "normal" \
+                --a "${APP_NAME}" \
+                --i "${NOTIFICATION_ICON}" \
+                --s "Battery Low" \
+                --m "Remaining: ${CAPACITY}%"
             NOTIFIED_20=true
         elif [[ $CAPACITY -gt 20 ]]; then
             NOTIFIED_20=false

--- a/dotfiles/.config/ml4w/scripts/arch/installprinters.sh
+++ b/dotfiles/.config/ml4w/scripts/arch/installprinters.sh
@@ -16,6 +16,9 @@ figlet -f smslant "Printers"
 # Confirm Start
 # ------------------------------------------------------
 
+# Notifications
+source "$HOME/.config/ml4w/scripts/notification-handler.sh"
+
 if gum confirm "DO YOU WANT TO START TO INSTALL PRINTER SYSTEM NOW?"; then
     echo
     echo ":: Install started."
@@ -47,7 +50,12 @@ fi
 
 yay -S cups cups-pdf cups-filters nss-mdns system-config-printer foomatic-db footmatic-db-engine foomatic-db-nonfree doomatic-db-nonfree-ppds foomatic-db-ppds cups-browsed libusb ipp-usb xdg-utils colord logrotate
 
-notify-send "Installing printer system complete"
+notify_user \
+    --a "System" \
+    --i "printer-symbolic" \
+    --s "Printers" \
+    --m "Installing printer system complete"
+
 echo
 echo ":: Installing printer system complete"
 sleep 2

--- a/dotfiles/.config/ml4w/scripts/notification-handler.sh
+++ b/dotfiles/.config/ml4w/scripts/notification-handler.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+DEFAULT_ICON="notifications-symbolic"
+
+notify_user() {
+    local icon="$DEFAULT_ICON"
+    local urgency="low"
+    local time=""
+    local app=""
+    local summary=""
+    local message=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --icon|--i|-i)
+            icon="$2"
+            shift 2
+            ;;
+        --urgency|--u|-u)
+            urgency="$2"
+            shift 2
+            ;;
+        --app|--a|-a)
+            app="$2"
+            shift 2
+            ;;
+        --time|--t|-t)
+            time="$2"
+            shift 2
+            ;;
+        --summary|--s|-s)
+            summary="$2"
+            shift 2
+            ;;
+        --message|--m|-m)
+            message="$2"
+            shift 2
+            ;;
+        --extra|--e|-e)
+            # split string into words
+            read -r -a extra <<< "$2"
+            shift 2
+            ;;
+        *)
+            echo "notify_user: unknown option: $1" >&2
+            return 1
+            ;;
+        esac
+    done
+
+    # ---- Mandatory argument checks ----
+    if [[ -z "$summary" && -z "$app" ]]; then
+        echo "notify_user: --summary or --app is required" >&2
+        return 1
+    fi
+
+    # ---- Normalize summary/app ----
+    [[ -z "$summary" ]] && summary="$app"
+    [[ -z "$app"   ]] && app="$summary"
+
+    # ---- Icon validation ----
+    if [[ "$icon" != "$DEFAULT_ICON" ]]; then
+        if [[ -f "$icon" && "$icon" =~ \.(png|svg)$ ]]; then
+            :
+        elif [[ ! "$icon" =~ / ]]; then
+            :
+        else
+            icon="$DEFAULT_ICON"
+        fi
+    fi
+
+    local notify_args=(
+        -u "$urgency"
+        -i "$icon"
+        -a "$app"
+    )
+
+    # Uses expiry time if informed
+    [[ -n "$time" ]] && notify_args+=(-t "$time")
+    # Uses other params as is
+    [[ ${#extra[@]} -gt 0 ]] && notify_args+=("${extra[@]}")
+
+    notify-send "${notify_args[@]}" "$summary" "$message"
+
+}


### PR DESCRIPTION
### Description

Introduces a centralized `notify_user` helper and migrates all direct `notify-send` invocations to use it. The new handler standardizes notification arguments and adds an --extra escape hatch for advanced `notify-send` options (e.g. replace-id, hints) without leaking complexity into callers.

### Changes
- [x] Improved
- [ ] Bug Fixes
- [ ] Feature
- [ ] Documentation
- [ ] Other

### Context

Notifications were sent via `notify-send` calls with inconsistent defaults and flags. This change reduces repetition, enforces consistent behavior (urgency, app name, icons), and makes future notification-related changes localized to a single script.
Before, all notifications were grouped under the generic _notify-send_ application name; the new helper ensures each notification is sent with an explicit app name, improving grouping, filtering, and visual clarity in the the notification center.

**Additional benefits**

- Single point of control for notification defaults and validation
- Easier future changes (e.g. switching notification service, adding logging, theming)
- Reduced copy-paste errors and flag drift across scripts
- Clear extension path for advanced features via --extra without API churn

### How Has This Been Tested?

- [ ] Tested on Arch Linux/Based Distro.
- [x] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

N/A

### Related Issues

N/A

### Additional Notes

N/A
