### PR TITLE
Refactor the references to $color8 and $color11 in the config files.

### DIFF
--- a/dotfiles/.config/hypr/conf/windows/border-1-reverse.conf
+++ b/dotfiles/.config/hypr/conf/windows/border-1-reverse.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 1
-    col.active_border = $color8
-    col.inactive_border = $color11
+    col.active_border = $primary
+    col.inactive_border = $on_surface
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/border-1.conf
+++ b/dotfiles/.config/hypr/conf/windows/border-1.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 1
-    col.active_border = $color11
-    col.inactive_border = $color8
+    col.active_border = $on_surface
+    col.inactive_border = $primary
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/border-2-reverse.conf
+++ b/dotfiles/.config/hypr/conf/windows/border-2-reverse.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 2
-    col.active_border = $color8
-    col.inactive_border = $color11
+    col.active_border = $primary
+    col.inactive_border = $on_surface
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/border-2.conf
+++ b/dotfiles/.config/hypr/conf/windows/border-2.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 2
-    col.active_border = $color11
-    col.inactive_border = $color8
+    col.active_border = $on_surface
+    col.inactive_border = $primary
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/border-3-reverse.conf
+++ b/dotfiles/.config/hypr/conf/windows/border-3-reverse.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 3
-    col.active_border = $color8
-    col.inactive_border = $color11
+    col.active_border = $primary
+    col.inactive_border = $on_surface
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/border-3.conf
+++ b/dotfiles/.config/hypr/conf/windows/border-3.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 3
-    col.active_border = $color11
-    col.inactive_border = $color8
+    col.active_border = $on_surface
+    col.inactive_border = $primary
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/border-4-reverse.conf
+++ b/dotfiles/.config/hypr/conf/windows/border-4-reverse.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 4
-    col.active_border = $color8
-    col.inactive_border = $color11
+    col.active_border = $primary
+    col.inactive_border = $on_surface
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/border-4.conf
+++ b/dotfiles/.config/hypr/conf/windows/border-4.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 4
-    col.active_border = $color11
-    col.inactive_border = $color8
+    col.active_border = $on_surface
+    col.inactive_border = $primary
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/default.conf
+++ b/dotfiles/.config/hypr/conf/windows/default.conf
@@ -7,7 +7,7 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 1
-    col.active_border = $color8 $on_primary 90deg
+    col.active_border = $primary $on_primary 90deg
     col.inactive_border = $on_primary
     layout = dwindle
     resize_on_border = true

--- a/dotfiles/.config/hypr/conf/windows/gamemode.conf
+++ b/dotfiles/.config/hypr/conf/windows/gamemode.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 0
     gaps_out = 0
     border_size = 1
-    col.active_border = $color11
-    col.inactive_border = $color8
+    col.active_border = $on_surface
+    col.inactive_border = $primary
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/glass.conf
+++ b/dotfiles/.config/hypr/conf/windows/glass.conf
@@ -7,7 +7,7 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 1
-    col.active_border = $color8 $on_primary 90deg
+    col.active_border = $primary $on_primary 90deg
     col.inactive_border = $on_primary
     layout = dwindle
     resize_on_border = true

--- a/dotfiles/.config/hypr/conf/windows/no-border-more-gaps.conf
+++ b/dotfiles/.config/hypr/conf/windows/no-border-more-gaps.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 20
     gaps_out = 40
     border_size = 0
-    col.active_border = $color11
-    col.inactive_border = $color8
+    col.active_border = $on_surface
+    col.inactive_border = $primary
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/conf/windows/no-border.conf
+++ b/dotfiles/.config/hypr/conf/windows/no-border.conf
@@ -7,8 +7,8 @@ general {
     gaps_in = 10
     gaps_out = 20
     border_size = 0
-    col.active_border = $color11
-    col.inactive_border = $color8
+    col.active_border = $on_surface
+    col.inactive_border = $primary
     layout = dwindle
     resize_on_border = true
 }

--- a/dotfiles/.config/hypr/hyprland.conf
+++ b/dotfiles/.config/hypr/hyprland.conf
@@ -34,8 +34,8 @@ source = ~/.config/hypr/conf/keyboard.conf
 # Load color file
 # -----------------------------------------------------
 source = ~/.config/hypr/colors.conf
-$color8 = $primary
-$color11 = $on_surface
+$primary = $primary
+$on_surface = $on_surface
 
 # -----------------------------------------------------
 # Autostart


### PR DESCRIPTION
### Description

This small pull request removes the references to $color8 and $color11 from the config files and replaces them with the intended matugen color references.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [x] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

I don't know if those are still there because of using wallust in the past but it makes more sense to just reference the matugen color directly instead, specially since this is done only for 2 specific colors, not a full color remapping to different variables.

Honestly, I wouldn't go as far as saying this is **necessary** refactor but it was a bit confusing and felt like a remaining part of old code that was not cleaned up and it was a very small job. I have stumbled upon it  on my local environment while doing other config stuff and changed it for myself. since it's working, I thought why not clean it up in the main repo as well.

Let me know if there were any specific reason why this was declared here besides the config file usage, but so far I have encountered no issues with it after a few days in my local environment.
 
### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [ ] Tested on Arch Linux/Based Distro.
- [x] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

N/A

### Related Issues

N/A

### Additional Notes

N/A