### PR TITLE
feat: add float+pin window toggle

### DIFF
--- a/dotfiles/.config/hypr/conf/keybindings/default.conf
+++ b/dotfiles/.config/hypr/conf/keybindings/default.conf
@@ -27,6 +27,7 @@ bind = $mainMod, F, fullscreen, 0                                               
 bind = $mainMod, M, fullscreen, 1                                                           # Maximize Window
 bind = $mainMod, T, togglefloating                                                          # Toggle active windows into floating mode
 bindd = $mainMod SHIFT, T, Float all windows, exec, ~/.config/ml4w/scripts/ml4w-toggle-allfloat # Toggle floating for all windows of workspace
+bind = $mainMod ALT, T, exec, ~/.config/ml4w/scripts/ml4w-toggle-float-pin                  # Toggle active window into floating + pinned mode
 bind = $mainMod, J, layoutmsg, togglesplit                                                  # Toggle split
 bind = $mainMod, left, movefocus, l                                                         # Move focus left
 bind = $mainMod, right, movefocus, r                                                        # Move focus right

--- a/dotfiles/.config/ml4w/scripts/ml4w-toggle-float-pin
+++ b/dotfiles/.config/ml4w/scripts/ml4w-toggle-float-pin
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Toggle floating and pinning (sticky) for the active window
+hyprctl dispatch togglefloating
+hyprctl dispatch pin


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This pull request adds a new keybind <kbd>Super</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd> that uses a simple 2-line hyprctl dispatch script to toggle floating + pinning (sticky) mode for the active window.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [x] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->

I found this feature useful when I want a floating window to be visible even when switching workspaces. The window can be easily toggled back to not be floating and pinned by pressing <kbd>Super</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd> again or even just <kbd>Super</kbd>+<kbd>T</kbd>.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->
<img width="1920" height="1080" alt="screenshot_20260309_122841" src="https://github.com/user-attachments/assets/082b1e57-f611-4855-81ed-b8dee2177067" />
<img width="1920" height="1080" alt="screenshot_20260309_123245" src="https://github.com/user-attachments/assets/1159264f-938b-4d70-9fc3-fdc8e6b18eeb" />

### Additional Notes

In my ``custom.conf`` I have switched the keybindings for the "float all windows" toggle and my float+pin window toggle, so my float+pin window toggle keybind is actually <kbd>Super</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> which is easier to press, as I find I use the feature much more than the "float all windows" toggle. It also better aligns with the standard keybinding <kbd>Super</kbd>+<kbd>Shift</kbd>+<kbd>[1-9]</kbd> to move a window to another workspace. But in the interest of not messing with pre-existing default keybinds, I have not made this switch in this PR.