### PR TITLE
Fix: Correct match paths for Hyprland Window and Workspace variants (error based on Quickshell)

### DIFF
--- a/dotfiles/.config/ml4w-dotfiles-settings/com.ml4w.dotfiles/settings.json
+++ b/dotfiles/.config/ml4w-dotfiles-settings/com.ml4w.dotfiles/settings.json
@@ -127,7 +127,7 @@
         "type": "files",
         "folder": "~/.config/hypr/conf/windows",
         "mode": "replace",
-        "match": "source = ~/.config/hypr/conf/window/.*",
+        "match": "source = ~/.config/hypr/conf/windows/.*",
         "default": "default.conf"
     },{
         "name": "Workspace Variants",
@@ -137,7 +137,7 @@
         "type": "files",
         "folder": "~/.config/hypr/conf/workspaces",
         "mode": "replace",
-        "match": "source = ~/.config/hypr/conf/workspace/.*",
+        "match": "source = ~/.config/hypr/conf/workspaces/.*",
         "default": "default.conf"
     },{
         "name": "Select Waybar Theme",


### PR DESCRIPTION
### Description
This pull request fixes incorrect match paths in `settings.json` for Hyprland Window and Workspace variants.

### Changes
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
  - Corrected singular directory names (`window`, `workspace`) to plural (`windows`, `workspaces`) in match paths.

### Context
The original configuration used singular directory names in the match paths. However, the actual directories that exist in the filesystem are plural (windows, workspaces), so the dropdowns failed to apply the correct configs.
This change resolves issue #1513  in the upstream repository and ensures Window and Workspace variant dropdowns work correctly.

### How Has This Been Tested?
- [x] Tested on Arch Linux/Based Distro.  
Confirmed that both Window and Workspace variant dropdowns now correctly source the intended config files.

### Checklist
- [x] My code follows the style guidelines of this project.  
- [x] I have performed a self-review of my code.  
- [x] My changes do not introduce new warnings.  
- [x] New and existing unit tests pass locally with my changes.  

### Screenshots
N/A — no UI changes, only config path corrections.

### Related Issues
Fixes #1513 

### Additional Notes
Signed-off-by: RISHIT GHOSH [`rishitghosh06@gmail.com`](mailto:rishitghosh06@gmail.com)
