### PR TITLE
Update hypridle.conf because apps like Thunderbird fall asleep 

### DIFF
--- a/dotfiles/.config/hypr/hypridle.conf
+++ b/dotfiles/.config/hypr/hypridle.conf
@@ -3,6 +3,8 @@ general {
     # lock_cmd = playerctl --all-players pause && pidof hyprlock || hyprlock  # pause all system audio and avoid starting multiple hyprlock instances.
     before_sleep_cmd = loginctl lock-session    # lock before suspend.
     after_sleep_cmd = hyprctl dispatch dpms on  # to avoid having to press a key twice to turn on the display.
+    ignore_wayland_inhibit = true
+    ignore_dbus_inhibit = true
 }
 
 listener {


### PR DESCRIPTION
Apps such as Thunderbird should fetch emails and execute scheduled rules even when the window is not currently in focus or the system is locked. With the old setting, apps like thunderbird fall asleep, when not in window focus or hyprland is locked.

Hyprland (via the Wayland protocol ext-idle-notify-v1) marks the system as "idle" as soon as Thunderbird loses focus – Thunderbird sends no or weak inhibitor signals, so hypridle triggers the idle listeners and throttles/pauses processes (timers, IMAP queries).

Adding:
- ignore_wayland_inhibit = true: Ignores Wayland protocol idle inhibitors (e.g. from Firefox/Thunderbird), so that hypridle is always considered idle, regardless of what apps signal.

- ignore_dbus_inhibit = true: Ignores DBus inhibit requests (e.g. systemd-inhibit --what=idle from Mozilla apps), preventing apps from blocking idle events.

Result: hypridle ignores all "I'm active" signals from Thunderbird and maintains its timeout logic without pausing background processes. Thunderbird continues to run as expected and fetches mails, even when not in focus.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [X ] Tested on Arch Linux/Based Distro.

- start thunderbird
- open console and enter `ps -C thunderbird -o time` different times (the Thunderbird window must not have the focus!)
- after some seconds, the value `TIME` no longer changes - Thunderbird is in freeze mode.
- point the focus to Thunderbird and do something with it
- `ps -C thunderbird -o time` in your console again - the value `TIME` will be higher

With this change, Thunderbird continues to work, even when the focus is not on it.
