### PR TITLE
Fix: Update green color definition in kitty-colors.conf

### DIFF
--- a/dotfiles/.config/matugen/templates/kitty-colors.conf
+++ b/dotfiles/.config/matugen/templates/kitty-colors.conf
@@ -16,7 +16,7 @@ color1   {{colors.error.default.hex}}
 color9   #c49ea0
 
 # green
-color2   {{colors.on_surface.default.hex}}
+color2   {{base16.base0b.default.hex}}
 color10  #9ec49f
 
 # yellow


### PR DESCRIPTION


### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This PR changes the green color in the matugen-generated Kitty color file to a color that is consistently green across different palettes. 


### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->

The current color (colors.on_surface) is often undistiguishable from the default font color, including with all the default wallpapers. This means reviewing git diffs is very frustrating, as only the removed lines pop out in red.

The `base16.base0b` color is consistently green in all the palettes I've tested, so I suggest we use that in the Kitty color scheme. FWIW this color name is also [documented](https://iniox.github.io#matugen/templates/base16) as green by matugen.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->
This is how a git diff currently looks like:
<img width="1144" height="321" alt="image" src="https://github.com/user-attachments/assets/5f5f2324-38a0-4d13-89fa-092e71cc7004" />
This is how the same looks like with my change:
<img width="1116" height="321" alt="image" src="https://github.com/user-attachments/assets/2533df37-fba4-4933-bb0c-458150060d83" />

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->

### Additional Notes

<!-- Add any other context, technical details, or considerations you'd like to share. -->
Thanks for your work on this project!