### PR TITLE
Remove deprecated  property

### DIFF
--- a/dotfiles/.config/hypr/conf/layouts/laptop.lua
+++ b/dotfiles/.config/hypr/conf/layouts/laptop.lua
@@ -4,7 +4,6 @@
 
 hl.config({
     dwindle = {
-        pseudotile = true,
         preserve_split = true,
     },
     


### PR DESCRIPTION
### Description

psuedotile is no longer support in hyprland 0.55; removing from laptop.lua config file.