### PR TITLE
feat: add fr workspace shortcut

### DIFF
--- a/dotfiles/.config/hypr/conf/keybindings/default.lua
+++ b/dotfiles/.config/hypr/conf/keybindings/default.lua
@@ -9,8 +9,26 @@ hl.bind(mainMod .. " + CTRL + E", hl.dsp.exec_cmd("~/.config/ml4w/settings/emoji
 hl.bind(mainMod .. " + CTRL + C", hl.dsp.exec_cmd("~/.config/ml4w/settings/calculator.sh"), { description = "Open the calculator" })
 
 -- Move active window to a workspace with mainMod + SHIFT + [0-9]
+local is_fr = false
+local f = io.open(os.getenv("HOME") .. "/.config/hypr/input.lua", "r")
+if f then
+    local content = f:read("*all")
+    if content:match('kb_layout%s*=%s*"fr"') then
+        is_fr = true
+    end
+    f:close()
+end
+
+local fr_keys = {
+    "ampersand", "eacute", "quotedbl", "apostrophe", "parenleft",
+    "minus", "egrave", "underscore", "ccedilla", "agrave"
+}
+
 for i = 1, 10 do
     local key = i % 10 -- 10 maps to key 0
+    if is_fr then
+        key = fr_keys[i]
+    end
     hl.bind(mainMod .. " + " .. key,             hl.dsp.focus({ workspace = i}), { description = "Focus workspace " .. i })
     hl.bind(mainMod .. " + SHIFT + " .. key,     hl.dsp.window.move({ workspace = i }), { description = "Move window to workspace " .. i })
 end


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This pull request adds the possibility to switch workspaces when the input.lua is set for fr :).

### Changes
- [ X ] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->
if keybord layout set to fr it's impossible to switch workspace otherwise :)

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [X] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->

### Additional Notes

<!-- Add any other context, technical details, or considerations you'd like to share. -->
