### PR TITLE
fix: correct binary path and unupported command-line argument

### DIFF
--- a/dotfiles/.config/ml4w/listeners/gtk-theme-switcher.sh
+++ b/dotfiles/.config/ml4w/listeners/gtk-theme-switcher.sh
@@ -28,6 +28,15 @@ apply_theme() {
         return 1
     fi
 
+    # Determine matugen binary path
+    if [ -f $HOME/.cargo/bin/matugen ]; then
+        MATUGEN_BIN="$HOME/.cargo/bin/matugen"
+    elif [ -f $HOME/.local/bin/matugen ]; then
+        MATUGEN_BIN="$HOME/.local/bin/matugen"
+    else
+        MATUGEN_BIN="matugen"
+    fi
+
     # Extract the value of gtk-application-prefer-dark-theme
     # We use grep to find the line and awk to get the value after the '='
     THEME_PREF=$(grep -E '^gtk-application-prefer-dark-theme=' "$SETTINGS_FILE" | awk -F'=' '{print $2}')
@@ -39,11 +48,7 @@ apply_theme() {
 
     if [[ "$THEME_PREF" == "1" || "$THEME_PREF" == "true" ]]; then
         echo "Detected dark theme preference (gtk-application-prefer-dark-theme=1/true). Applying dark matugen theme..."
-        if [ -f $HOME/.cargo/bin/matugen ]; then
-            $HOME/.cargo/bin/matugen image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) --source-color-index 0 -m "dark"
-        else
-            matugen image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) --source-color-index 0 -m "dark"
-        fi
+        $MATUGEN_BIN image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) --source-color-index 0 -m "dark"
 
         # Update Quickshell theme
         qs ipc call theme-manager reload
@@ -66,12 +71,7 @@ apply_theme() {
         swaync-client -rs
     elif [[ "$THEME_PREF" == "0" || "$THEME_PREF" == "false" ]]; then
         echo "Detected light theme preference (gtk-application-prefer-dark-theme=0/false). Applying light matugen theme..."
-        
-        if [ -f $HOME/.cargo/bin/matugen ]; then
-            $HOME/.cargo/bin/matugen image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) --source-color-index 0 -m "light"
-        else
-            matugen image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) --source-color-index 0 -m "light"
-        fi
+        $MATUGEN_BIN image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) --source-color-index 0 -m "light"
 
         # Update Quickshell theme
         qs ipc call theme-manager reload

--- a/dotfiles/.config/ml4w/listeners/gtk-theme-switcher.sh
+++ b/dotfiles/.config/ml4w/listeners/gtk-theme-switcher.sh
@@ -48,7 +48,7 @@ apply_theme() {
 
     if [[ "$THEME_PREF" == "1" || "$THEME_PREF" == "true" ]]; then
         echo "Detected dark theme preference (gtk-application-prefer-dark-theme=1/true). Applying dark matugen theme..."
-        $MATUGEN_BIN image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) --source-color-index 0 -m "dark"
+        $MATUGEN_BIN image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) -m "dark"
 
         # Update Quickshell theme
         qs ipc call theme-manager reload
@@ -71,7 +71,7 @@ apply_theme() {
         swaync-client -rs
     elif [[ "$THEME_PREF" == "0" || "$THEME_PREF" == "false" ]]; then
         echo "Detected light theme preference (gtk-application-prefer-dark-theme=0/false). Applying light matugen theme..."
-        $MATUGEN_BIN image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) --source-color-index 0 -m "light"
+        $MATUGEN_BIN image $(cat ~/.cache/ml4w/hyprland-dotfiles/current_wallpaper) -m "light"
 
         # Update Quickshell theme
         qs ipc call theme-manager reload

--- a/dotfiles/.config/ml4w/scripts/ml4w-wallpaper
+++ b/dotfiles/.config/ml4w/scripts/ml4w-wallpaper
@@ -205,19 +205,20 @@ fi
 SETTINGS_FILE="$HOME/.config/gtk-3.0/settings.ini"
 THEME_PREF=$(grep -E '^gtk-application-prefer-dark-theme=' "$SETTINGS_FILE" | awk -F'=' '{print $2}')
 
+# Determine matugen binary path
+if [ -f $HOME/.cargo/bin/matugen ]; then
+    MATUGEN_BIN="$HOME/.cargo/bin/matugen"
+elif [ -f $HOME/.local/bin/matugen ]; then
+    MATUGEN_BIN="$HOME/.local/bin/matugen"
+else
+    MATUGEN_BIN="matugen"
+fi
+
 # Execute matugen
 if [ "$THEME_PREF" -eq 1 ]; then
-    if [ -f $HOME/.cargo/bin/matugen ]; then
-        $HOME/.cargo/bin/matugen image "$IMAGE_PATH" --source-color-index 0 -m "dark"
-    else
-        matugen image "$IMAGE_PATH" --source-color-index 0 -m "dark"
-    fi
+    $MATUGEN_BIN image "$IMAGE_PATH" --source-color-index 0 -m "dark"
 else
-    if [ -f $HOME/.cargo/bin/matugen ]; then
-        $HOME/.cargo/bin/matugen image "$IMAGE_PATH" --source-color-index 0 -m "light"
-    else
-        matugen image "$IMAGE_PATH" --source-color-index 0 -m "dark"
-    fi
+    $MATUGEN_BIN image "$IMAGE_PATH" --source-color-index 0 -m "light"
 fi
 info "Matugen updated"
 

--- a/dotfiles/.config/ml4w/scripts/ml4w-wallpaper
+++ b/dotfiles/.config/ml4w/scripts/ml4w-wallpaper
@@ -216,9 +216,9 @@ fi
 
 # Execute matugen
 if [ "$THEME_PREF" -eq 1 ]; then
-    $MATUGEN_BIN image "$IMAGE_PATH" --source-color-index 0 -m "dark"
+    $MATUGEN_BIN image "$IMAGE_PATH" -m "dark"
 else
-    $MATUGEN_BIN image "$IMAGE_PATH" --source-color-index 0 -m "light"
+    $MATUGEN_BIN image "$IMAGE_PATH" -m "light"
 fi
 info "Matugen updated"
 


### PR DESCRIPTION
### Description

This pull request fixes automatic theme color generation failing when changing wallpapers. It resolves binary path lookup issues for `matugen`, removes the unsupported `--source-color-index` argument, and corrects theme preference fallback logic.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

Users with `matugen` installed at `~/.local/bin/matugen` experienced silent color update failures when changing wallpapers via Waypaper. This was caused by three issues:
1. `~/.local/bin/` is often absent from the environment `$PATH` of background daemons running Waypaper.
2. The `--source-color-index` option is unsupported/unexpected in current versions of `matugen`, causing the execution to crash immediately with exit code 2.
3. The fallback path for the light-theme branch in `ml4w-wallpaper` incorrectly hardcoded the `-m "dark"` flag.

This PR adds a robust path detector for the binary (`$HOME/.cargo/bin`, `$HOME/.local/bin`, and system fallback), removes the deprecated argument, and ensures light and dark modes are properly respected.

### How Has This Been Tested?

- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->

### Related Issues

Fixes #1618 

### Additional Notes

The helper logic determines the proper executable via:
```bash
if [ -f $HOME/.cargo/bin/matugen ]; then
    MATUGEN_BIN="$HOME/.cargo/bin/matugen"
elif [ -f $HOME/.local/bin/matugen ]; then
    MATUGEN_BIN="$HOME/.local/bin/matugen"
else
    MATUGEN_BIN="matugen"
fi