### PR TITLE
fix: migrate toggle float-pin to lua inline hyprctl dispatch

### DIFF
--- a/dotfiles/.config/hypr/conf/keybindings/default.lua
+++ b/dotfiles/.config/hypr/conf/keybindings/default.lua
@@ -41,7 +41,7 @@ hl.bind(mainMod .. " + SHIFT + Q", hl.dsp.exec_cmd("hyprctl activewindow | grep 
 hl.bind(mainMod .. " + F", hl.dsp.window.fullscreen({ mode = "fullscreen", action = "toggle" }), { description = "Toggle Fullscreen" })
 hl.bind(mainMod .. " + T", hl.dsp.window.float({ action = "toggle" }), { description = "Toggle Floating" })
 hl.bind(mainMod .. " + SHIFT + T", hl.dsp.exec_cmd("~/.config/ml4w/scripts/ml4w-toggle-allfloat"), { description = "Toggle floating for all windows of workspace" })
-hl.bind(mainMod .. " + ALT + T", hl.dsp.exec_cmd("~/.config/ml4w/scripts/ml4w-toggle-float-pin"), { description = "Toggle active window into floating + pinned mode" })
+hl.bind(mainMod .. " + ALT + T", function() hl.dispatch(hl.dsp.window.float({ action = "toggle" })); hl.dispatch(hl.dsp.window.pin()) end, { description = "Toggle floating + pinned" })
 hl.bind(mainMod .. " + J", hl.dsp.layout("togglesplit"), { description = "Toggle split" })
 hl.bind(mainMod .. " + left",  hl.dsp.focus({ direction = "left" }), { description = "Move focus left" })
 hl.bind(mainMod .. " + right", hl.dsp.focus({ direction = "right" }), { description = "Move focus right" })

--- a/dotfiles/.config/ml4w/scripts/ml4w-toggle-float-pin
+++ b/dotfiles/.config/ml4w/scripts/ml4w-toggle-float-pin
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-# Toggle floating and pinning (sticky) for the active window
-hyprctl dispatch togglefloating
-hyprctl dispatch pin


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This pull request fixes the <kbd> SUPER </kbd> + <kbd> ALT </kbd> + <kbd> T </kbd> float + pin window toggle keybind that was broken due to the Hyprland v0.55.0 "Lua-ification" update.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->
Recent updates to Hyprland introduced breaking changes to how `hyprctl dispatch` handles external scripts for toggle operations. As a result, the existing `ml4w-toggle-float-pin` script no longer works.

This PR removes the external script entirely and shifts the logic directly into `default.lua` using native CLI commands, restoring the toggle functionality.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->

### Additional Notes

<!-- Add any other context, technical details, or considerations you'd like to share. -->
