### PR TITLE
Update keybindings default.lua to add missing cycle active group window

### DIFF
--- a/dotfiles/.config/hypr/conf/keybindings/default.lua
+++ b/dotfiles/.config/hypr/conf/keybindings/default.lua
@@ -54,6 +54,7 @@ hl.bind(mainMod .. " + SHIFT + left", hl.dsp.window.resize({ x = -100, y = 0 }),
 hl.bind(mainMod .. " + SHIFT + down", hl.dsp.window.resize({ x = 0, y = 100 }), { description = "Increase window height with keyboard" })
 hl.bind(mainMod .. " + SHIFT + up", hl.dsp.window.resize({ x = 0, y = -100 }), { description = "Reduce window height with keyboard" })
 hl.bind(mainMod .. " + G", hl.dsp.group.toggle(), { description = "Toggle window group" })
+hl.bind(mainMod .. " + SHIFT + G", hl.dsp.group.active("f"), { description = "Switch to next group window" })
 hl.bind(mainMod .. " + K", hl.dsp.layout("swapsplit"), { description = "Swapsplit" })
 hl.bind(mainMod .. " + ALT + left", hl.dsp.window.swap({ direction = "l" }), { description = "Swap tiled window left" })
 hl.bind(mainMod .. " + ALT + right", hl.dsp.window.swap({ direction = "r" }), { description = "Swap tiled window right" })


### PR DESCRIPTION
Add keybinding to cycle active group window

### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This pull request adds a new default keybinding (`SUPER + SHIFT + G`) to cycle forward through windows within an active group.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [x] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

Currently, the `default.lua` keybindings includes a bind to toggle window groups (`SUPER + G`), but lacks a default binding to navigate between the windows once they are grouped forcing mouse use. This addition makes the grouping functionality fully usable out-of-the-box. I mapped it to available `SUPER + SHIFT + G` so it stays intuitively clustered with the existing group toggle bind.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

Not applicable (backend keybinding addition).

### Related Issues

N/A

### Additional Notes

<!-- Add any other context, technical details, or considerations you'd like to share. -->
This is my very first open-source pull request!
