### PR TITLE
Support jpg, ppm file format preference for screenshots

### DIFF
--- a/dotfiles/.config/hypr/scripts/screenshot.sh
+++ b/dotfiles/.config/hypr/scripts/screenshot.sh
@@ -11,16 +11,33 @@
 # Screenshots will be stored in $HOME by default.
 # The screenshot will be moved into the screenshot directory
 
-# Add this to ~/.config/user-dirs.dirs to save screenshots in a custom folder:
-# XDG_SCREENSHOTS_DIR="$HOME/Screenshots"
+# Defaults
+SAVE_DIR="$HOME/Pictures"
+SAVE_FILENAME="screenshot_$(date +%d%m%Y_%H%M%S).jpg"
 
-prompt='Screenshot'
-mesg="DIR: ~/Screenshots"
+# Load Settings
+if [ -f ~/.config/ml4w/settings/screenshot-folder ]; then
+    SAVE_DIR=$(cat ~/.config/ml4w/settings/screenshot-folder)
+fi
+if [ -f ~/.config/ml4w/settings/screenshot-filename ]; then
+    SAVE_FILENAME=$(cat ~/.config/ml4w/settings/screenshot-filename)
+fi
 
-SAVE_DIR=$(cat ~/.config/ml4w/settings/screenshot-folder)
-SAVE_FILENAME=$(cat ~/.config/ml4w/settings/screenshot-filename)
 eval screenshot_folder="$SAVE_DIR"
 eval NAME="$SAVE_FILENAME"
+
+# Get image format
+image_format="png"
+extension="${NAME##*.}"
+
+case $extension in
+    "jpg"|"jpeg")
+        image_format="jpeg"
+        ;;
+    "ppm")
+        image_format="ppm"
+        ;;
+esac
 
 # Notifications
 source "$HOME/.config/ml4w/scripts/ml4w-notification-handler"
@@ -30,15 +47,9 @@ NOTIFICATION_ICON="camera-photo-symbolic"
 # Screenshot Editor
 export GRIMBLAST_EDITOR="$(cat ~/.config/ml4w/settings/screenshot-editor)"
 
-# Example for keybindings
-# bind = SUPER, p, exec, grimblast save active
-# bind = SUPER SHIFT, p, exec, grimblast save area
-# bind = SUPER ALT, p, exec, grimblast save output
-# bind = SUPER CTRL, p, exec, grimblast save screen
-
 # Quick instant mode: full screen
 take_instant_full() {
-    grim "$NAME" && notify_user \
+    grim -t "$image_format" "$NAME" && notify_user \
         --a "${APP_NAME}" \
         --i "${NOTIFICATION_ICON}" \
         --s "Screenshot saved" \
@@ -67,7 +78,7 @@ take_instant_area() {
     trap - EXIT
 
     # capture and notify
-    grim -g "$region" "$NAME" && notify_user \
+    grim -g "$region" -t "$image_format" "$NAME" && notify_user \
         --a "${APP_NAME}" \
         --i "${NOTIFICATION_ICON}" \
         --s "Screenshot saved" \
@@ -197,16 +208,19 @@ copy_save_editor_exit() {
 }
 
 # Confirm and execute
+# Note: `grimblast` only supports png outpuut when copy is specified
 copy_save_editor_run() {
     selected_chosen="$(copy_save_editor_exit)"
     if [[ "$selected_chosen" == "$copy" ]]; then
         option_chosen=copy
+        image_format=png
         ${1}
     elif [[ "$selected_chosen" == "$save" ]]; then
         option_chosen=save
         ${1}
     elif [[ "$selected_chosen" == "$copy_save" ]]; then
         option_chosen=copysave
+        image_format=png
         ${1}
     elif [[ "$selected_chosen" == "$edit" ]]; then
         option_chosen=edit
@@ -244,7 +258,7 @@ timer() {
 # take shots
 takescreenshot() {
     sleep 1
-    grimblast --notify "$option_chosen" "$option_type_screenshot" $NAME
+    grimblast --notify "$option_chosen" --filetype "$image_format" "$option_type_screenshot" $NAME
     if [ -f $HOME/$NAME ]; then
         if [ -d $screenshot_folder ]; then
             mv $HOME/$NAME $screenshot_folder/
@@ -256,7 +270,7 @@ takescreenshot_timer() {
     sleep 1
     timer
     sleep 1
-    grimblast --notify "$option_chosen" "$option_type_screenshot" $NAME
+    grimblast --notify "$option_chosen" --filetype "$image_format" "$option_type_screenshot" $NAME
     if [ -f $HOME/$NAME ]; then
         if [ -d $screenshot_folder ]; then
             mv $HOME/$NAME $screenshot_folder/

--- a/dotfiles/.config/ml4w/bin/ml4w-screenshot
+++ b/dotfiles/.config/ml4w/bin/ml4w-screenshot
@@ -23,6 +23,19 @@ eval screenshot_folder="$SAVE_DIR"
 eval filename="$SAVE_FILENAME"
 path="$screenshot_folder/$filename"
 
+# Get image format
+image_format="png"
+extension="${filename##*.}"
+
+case $extension in
+    "jpg"|"jpeg")
+        image_format="jpeg"
+        ;;
+    "ppm")
+        image_format="ppm"
+        ;;
+esac
+
 # Create Screenshot folder
 mkdir -p "$SAVE_DIR"
 
@@ -40,18 +53,18 @@ take_screenshot() {
 
     case $mode in
         "fullscreen")
-            grim "$path"
+            grim -t "$image_format" "$path"
             ;;
         "area")
             # slurp allows UI selection
             GEOM=$(slurp)
             [ -z "$GEOM" ] && exit 0 # Handle ESC/Cancel
-            grim -g "$GEOM" "$path"
+            grim -g "$GEOM" -t "$image_format" "$path"
             ;;
         "window")
             # Hyprland specific geometry
             GEOM=$(hyprctl activewindow -j | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
-            grim -g "$GEOM" "$path"
+            grim -g "$GEOM" -t "$image_format" "$path"
             ;;
     esac
 


### PR DESCRIPTION
### Description
Today the screenshot utility uses `grim` and `grimblast` without specifying the `--type` parameter, resulting in all files being saved as PNG even if the preferred file format is `JPG`. This pull request modifies the screenshot logic to read the file format from `~/.config/ml4w/settings/screenshot-filename` and attempt to use that file format preference when using `grim` to save images.

### Changes
- [X] Modified `dotfiles/.config/ml4w/bin/ml4w-screenshot` utility to extract file extension from preference and extended support to `JPG` and `PPM` file formats.
- [X] Modified `dotfiles/.config/hypr/scripts/screenshot.sh` script to extract file extension from preference and extended support to `JPG` and `PPM` file formats (when applicable).
- [X] Updated `dotfiles/.config/hypr/scripts/screenshot.sh` script to use same default logic for folder and file preference as laid out in `dotfiles/.config/ml4w/bin/ml4w-screenshot`.

### Context

### How Has This Been Tested?
- [X] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Additional Notes

- `grimblast` only supports PNG file formats when copying the image to the clipboard. As a result, any request to "Copy" or "Copy & Save" will result in the file format always being PNG.
- `grim` and `grimblast` only support PNG, JPG, and PPM formats. Any other file format (e.g. WEBP) will result in the image being saved as a PNG. A potential future enhancement may be to allow for the script to convert the image via `imagemagick`, but that should require it's own PR with thought put towards any lossy issues with file format conversions.