### PR TITLE
fix keybindings on fr layout with us variant

### DIFF
--- a/dotfiles/.config/hypr/conf/keybindings/default.lua
+++ b/dotfiles/.config/hypr/conf/keybindings/default.lua
@@ -13,7 +13,7 @@ local is_fr = false
 local f = io.open(os.getenv("HOME") .. "/.config/hypr/input.lua", "r")
 if f then
     local content = f:read("*all")
-    if content:match('kb_layout%s*=%s*"fr"') then
+    if content:match('kb_layout%s*=%s*"fr"') and not content:match('kb_variant%s*=%s*"us"') then
         is_fr = true
     end
     f:close()


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
I added a second condition to set `is_fr` to `true` when `kb_layout` is equal to `fr`. Indeed, if `kb_variant` is set to `us` while `kb_layout` is set to `fr`, keyboard layout will remain in QWERTY, but with the possibility of entering accented letters using the AltGr key.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->
This change solve workspace keybindings issue, for users using `fr` layout with `us` variant.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->
https://github.com/mylinuxforwork/dotfiles/issues/1653

### Additional Notes

<!-- Add any other context, technical details, or considerations you'd like to share. -->
