### PR TITLE
Add waybar support for several users

### DIFF
--- a/dotfiles/.config/waybar/launch.sh
+++ b/dotfiles/.config/waybar/launch.sh
@@ -11,7 +11,7 @@
 # invocation proceeds; all others exit immediately.
 # -----------------------------------------------------
 
-lock_file="/tmp/waybar-launch-$USER.lock"
+lock_file="$XDG_RUNTIME_DIR/waybar-launch.lock"
 exec 200>$lock_file
 flock -n 200 || exit 0
 

--- a/dotfiles/.config/waybar/launch.sh
+++ b/dotfiles/.config/waybar/launch.sh
@@ -11,7 +11,7 @@
 # invocation proceeds; all others exit immediately.
 # -----------------------------------------------------
 
-lock_file="tmp/waybar-launch-$USER.lock"
+lock_file="/tmp/waybar-launch-$USER.lock"
 exec 200>$lock_file
 flock -n 200 || exit 0
 

--- a/dotfiles/.config/waybar/launch.sh
+++ b/dotfiles/.config/waybar/launch.sh
@@ -11,7 +11,8 @@
 # invocation proceeds; all others exit immediately.
 # -----------------------------------------------------
 
-exec 200>/tmp/waybar-launch.lock
+lock_file="tmp/waybar-launch-$USER.lock"
+exec 200>$lock_file
 flock -n 200 || exit 0
 
 # -----------------------------------------------------
@@ -97,12 +98,12 @@ _toggle_module() {
         search_string=" \"$module_name\""
         if ! grep -qF "$search_string" "$file"; then
             sed -i "s| //\"$module_name\"| \"$module_name\"|g" "$file"
-        fi    
+        fi
     else
         search_string=" //\"$module_name\""
         if ! grep -qF "$search_string" "$file"; then
             sed -i "s| \"$module_name\"| //\"$module_name\"|g" "$file"
-        fi    
+        fi
     fi
 }
 


### PR DESCRIPTION
### Description
Currently, to prevent waybar for running multiple time a loack file is used in `/tmp`. However `/tmp` is global for all local users which implies that only one instance of waybar can run.

### Changes
So, I used another file which is appended by the username of the current USER, so that every user has it's own lock fie.

### How Has This Been Tested?

- [X] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.
