### PR TITLE
Add keybind shortcut to change beyboard layout

### DIFF
--- a/dotfiles/.config/hypr/input.lua
+++ b/dotfiles/.config/hypr/input.lua
@@ -4,17 +4,17 @@
 
 hl.config({
     input = {
-        kb_layout  = "us",
-        kb_variant = "",
-        kb_model   = "",
-        kb_options = "",
-        kb_rules   = "",
+        kb_layout    = "us",
+        kb_variant   = "",
+        kb_model     = "",
+        kb_options   = "grp:win_space_toggle",
+        kb_rules     = "",
 
         follow_mouse = 1,
 
-        sensitivity = 0, -- -1.0 - 1.0, 0 means no modification.
+        sensitivity  = 0, -- -1.0 - 1.0, 0 means no modification.
 
-        touchpad = {
+        touchpad     = {
             natural_scroll = false,
         },
     },


### PR DESCRIPTION
### Description

I added an option in keyboard config which allow to switch layout with "SUPER + SPACE" I took this one because it's the same on windows and it's available.

### Changes
- [X] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

