### PR TITLE
fix nm-applet bug

### DIFF
--- a/dotfiles/.config/waybar/modules.json
+++ b/dotfiles/.config/waybar/modules.json
@@ -328,7 +328,7 @@
     "tooltip-format-disconnected": "Disconnected",
     "max-length": 50,
     "on-click": "~/.config/ml4w/settings/networkmanager.sh",
-    "on-click-right": "~/.config/ml4w/scripts/nm-applet.sh toggle",
+    "on-click-right": "~/.config/ml4w/scripts/ml4w-toggle-nmapplet toggle",
   },
   // Battery
   "battery": {


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This pull request fixes right click on network icon in waybar. nm-applet.sh has been replaced by ml4w-toggle-nmapplet, but modules.json has not been updated

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->
When right click on network icon in waybar, nothing happens. Normally this toggles network manager icon

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->

### Additional Notes

<!-- Add any other context, technical details, or considerations you'd like to share. -->
