### PR TITLE
Fix screen share by force-starting portal services (#1604)

### DIFF
--- a/dotfiles/.config/hypr/conf/autostart.conf
+++ b/dotfiles/.config/hypr/conf/autostart.conf
@@ -7,6 +7,10 @@
 # Start Listeners
 exec-once=~/.config/ml4w/listeners.sh --startall
 
+# Fix for #1604: Hyprland doesn't activate graphical-session.target, so portal services
+# never autostart without this. --ignore-dependencies bypasses that broken dependency chain.
+exec-once = systemctl --user start --ignore-dependencies xdg-desktop-portal-hyprland.service xdg-desktop-portal.service
+
 # Start Polkit
 exec-once=/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
 


### PR DESCRIPTION
### Description
Adds a single `exec-once` line to `autostart.conf` that force-starts both portal services on boot, fixing browser/OBS/Discord screen sharing.

### Changes
- [x] Bug Fixes

### Context
Hyprland never activates `graphical-session.target`. Both `xdg-desktop-portal.service` and `xdg-desktop-portal-hyprland.service` depend on that target via `Requisite=`/`PartOf=`, so they fail to start on boot with a dependency error. This breaks screencast entirely — Meet, Discord, and OBS all rely on these services. The fix force-starts both with `--ignore-dependencies`, bypassing the broken dependency check. Builds on the workaround originally posted by @anikmar in #1604, extended here to also cover `xdg-desktop-portal-hyprland.service`, which needs the same fix separately.

### How Has This Been Tested?
- [x] Tested on Arch Linux/Based Distro.

Confirmed `xdg-desktop-portal.service` and `xdg-desktop-portal-hyprland.service` both go `active (running)` after a fresh boot, and screen sharing works in Google Meet (browser) and OBS (PipeWire source).

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.

### Related Issues
Fixes #1604

### Additional Notes
Minimal, single-line diff in `autostart.conf` — no other files touched.