### PR TITLE
fix(hypridle): prevent screen lock during video playback

### DIFF
--- a/dotfiles/.config/hypr/hypridle.conf
+++ b/dotfiles/.config/hypr/hypridle.conf
@@ -3,8 +3,6 @@ general {
     # lock_cmd = playerctl --all-players pause && pidof hyprlock || hyprlock  # pause all system audio and avoid starting multiple hyprlock instances.
     before_sleep_cmd = loginctl lock-session    # lock before suspend.
     after_sleep_cmd = hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'  # to avoid having to press a key twice to turn on the display.
-    ignore_wayland_inhibit = true
-    ignore_dbus_inhibit = true
 }
 
 listener {


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
Respect idle inhibitors so the screen no longer locks while media is playing. Media players and browsers (Celluloid, YouTube, etc.) emit D-Bus/systemd idle-inhibit signals during playback, but these were being ignored, causing the session to lock after the timeout even with active video.
This pull request fixes #1658 .

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Related Issues
Fixes #1658 
