### PR TITLE
Refactor wallpaper cache and waybar launch logic

### DIFF
--- a/dotfiles/.config/hypr/conf/autostart.lua
+++ b/dotfiles/.config/hypr/conf/autostart.lua
@@ -25,6 +25,9 @@ hl.on("hyprland.start", function ()
     -- Start listeners
     hl.exec_cmd("~/.config/ml4w/listeners.sh --startall")
 
+    -- Start waybar
+    hl.exec_cmd(HOME .. "/.config/waybar/launch.sh")
+
     -- Start polkit daemon
     hl.exec_cmd("/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1")
 

--- a/dotfiles/.config/ml4w/scripts/ml4w-autostart
+++ b/dotfiles/.config/ml4w/scripts/ml4w-autostart
@@ -4,6 +4,7 @@
 CACHE_FOLDER="$HOME/.cache/ml4w/hyprland-dotfiles"
 CACHE_FILE="$CACHE_FOLDER/current_wallpaper"
 DEFAULT_WALLPAPER="$HOME/.config/ml4w/wallpapers/default.jpg"
+AWWW_CACHE_FOLDER="${XDG_CACHE_HOME:-"$HOME/.cache"}/awww"
 
 # Colors for UI
 RED='\033[0;31m'
@@ -49,9 +50,11 @@ done
 sleep 0.5
 info "Quickshell ready"
 
-# Set wallpaper — qs is guaranteed ready for IPC calls
-info "Set wallpaper to cache file $(cat $CACHE_FILE)"
-~/.config/ml4w/scripts/ml4w-wallpaper "$(cat $CACHE_FILE)" &
+# Set wallpaper only if awww cache is not setup — qs is guaranteed ready for IPC calls
+if [[ -z $(find "$AWWW_CACHE_FOLDER" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null) ]]; then
+    info "Set wallpaper to cache file $(cat $CACHE_FILE)"
+    ~/.config/ml4w/scripts/ml4w-wallpaper "$(cat $CACHE_FILE)" &
+fi
 
 # Start ML4W Settings App
 info "Starting ML4W Dotfiles Settings"


### PR DESCRIPTION
### Description

`awww` has its own method for caching and restoring wallpaper files when `awww-daemon` is started. Right now `ml4w-wallpaper` is called by `ml4w-autostart` which will use its own cache to set the wallpaper. This update first checks to see if the `awww` cache is set (i.e. `~/.cache/awww`), and if not set then will call `ml4w-wallpaper` which will set the wallpaper with its default file.

In factoring this logic, I discovered that `waybar` initialization was dependent on `ml4w-wallpaper` being called given how the autostart logic has been laid out. I added an explicit call to start `waybar` in `autostart.lua` since it makes more sense for that call to be made there.

### Changes
- [X] Updated  `ml4w-autostart to call `ml4w-wallpaper` only when the `awww` cache is not set
- [X] Updated `autostart.lua` to explicit start `waybar`

### How Has This Been Tested?

- [X] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Related Issues

Additional changes to support #1631 