### PR TITLE
Check presence of awww cache file instead of folder

### DIFF
--- a/dotfiles/.config/ml4w/scripts/ml4w-autostart
+++ b/dotfiles/.config/ml4w/scripts/ml4w-autostart
@@ -4,7 +4,8 @@
 CACHE_FOLDER="$HOME/.cache/ml4w/hyprland-dotfiles"
 CACHE_FILE="$CACHE_FOLDER/current_wallpaper"
 DEFAULT_WALLPAPER="$HOME/.config/ml4w/wallpapers/default.jpg"
-AWWW_CACHE_FOLDER="${XDG_CACHE_HOME:-"$HOME/.cache"}/awww"
+AWWW_DAEMON_VERSION="$(awww-daemon --version 2>/dev/null | awk '{ print $2 }')"
+AWWW_CACHE_FOLDER="${XDG_CACHE_HOME:-"$HOME/.cache"}/awww/$AWWW_DAEMON_VERSION"
 
 # Colors for UI
 RED='\033[0;31m'
@@ -51,7 +52,7 @@ sleep 0.5
 info "Quickshell ready"
 
 # Set wallpaper only if awww cache is not setup — qs is guaranteed ready for IPC calls
-if [[ -z $(find "$AWWW_CACHE_FOLDER" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null) ]]; then
+if [[ -z $(find "$AWWW_CACHE_FOLDER" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null) ]]; then
     info "Set wallpaper to cache file $(cat $CACHE_FILE)"
     ~/.config/ml4w/scripts/ml4w-wallpaper "$(cat $CACHE_FILE)" &
 fi


### PR DESCRIPTION
### Description

Addresses edge case in #1673 where `awww-daemon` is started before the `awww` cache folder is checked. Changed logic to look for files in the correct versioned folder as opposed to the folder itself. 

### Changes
- [X] Changes autostart logic to look at files in `awww` cache folder vs. the folders themselves

### How Has This Been Tested?

- [X] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

### Checklist

Please ensure your pull request meets the following requirements:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

### Related Issues

#1673 