### PR TITLE
fix(script): When no item is selected from the clipboard history, the…

### DIFF
--- a/dotfiles/.config/ml4w/scripts/ml4w-cliphist
+++ b/dotfiles/.config/ml4w/scripts/ml4w-cliphist
@@ -6,7 +6,6 @@
 #  \____|_|_| .__/|_| |_|_|___/\__|
 #           |_|
 #
-
 # -----------------------------------------------------
 # Load Launcher
 # -----------------------------------------------------
@@ -16,13 +15,17 @@ if [ "$launcher" == "walker" ]; then
 else
     case $1 in
         d)
-            cliphist list | rofi -dmenu -replace -config ~/.config/rofi/config-cliphist.rasi | cliphist delete
+            selected=$(cliphist list | rofi -dmenu -replace -config ~/.config/rofi/config-cliphist.rasi)
+            [ -z "$selected" ] && exit 0
+            echo "$selected" | cliphist delete
         ;;
-        w)    
+        w)
             cliphist wipe
         ;;
         *)
-            cliphist list | rofi -dmenu -replace -config ~/.config/rofi/config-cliphist.rasi | cliphist decode | wl-copy
+            selected=$(cliphist list | rofi -dmenu -replace -config ~/.config/rofi/config-cliphist.rasi)
+            [ -z "$selected" ] && exit 0
+            echo "$selected" | cliphist decode | wl-copy
         ;;
     esac
 fi


### PR DESCRIPTION
### Description
This pull request fixes the clipboard history script behavior when no item is selected from the menu.

### Changes
- [x] Bug Fixes <!-- Fixes Scripts/Other -->

### Context
When the clipboard history menu was invoked and the user closed it without selecting any item, the currently loaded clipboard content was overwritten with an empty value. This caused the previously copied text to be lost, forcing the user to reopen the history and select it again. Now, if no item is selected from the menu, the script exits cleanly without modifying the clipboard.

### How Has This Been Tested?
- [x] Tested on Arch Linux/Based Distro.

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes do not introduce new warnings.

### Additional Notes
The fix was applied by capturing the rofi selection into a variable and checking whether it is empty before piping it to `cliphist decode | wl-copy` or `cliphist delete`. If the selection is empty, the script exits with code 0.