### PR TITLE
[BUG FIX] Support boolean GTK theme preference in ml4w-wallpaper

### DIFF
--- a/dotfiles/.config/ml4w/scripts/ml4w-wallpaper
+++ b/dotfiles/.config/ml4w/scripts/ml4w-wallpaper
@@ -109,8 +109,14 @@ set_wallpaper() {
 run_matugen() {
     local theme_pref
     theme_pref=$(grep -E '^gtk-application-prefer-dark-theme=' "$HOME/.config/gtk-3.0/settings.ini" | awk -F'=' '{print $2}')
+    
     local mode="light"
-    [ "$theme_pref" -eq 1 ] && mode="dark"
+
+    case "$theme_pref" in
+        1|true)
+            mode="dark"
+            ;;
+    esac
 
     local bin="matugen"
     [ -f "$HOME/.cargo/bin/matugen" ] && bin="$HOME/.cargo/bin/matugen"


### PR DESCRIPTION
## Summary

`ml4w-wallpaper` determines whether to generate a light or dark Matugen theme by reading `gtk-application-prefer-dark-theme` from GTK settings.

The script currently only recognizes the numeric value `1` as Dark Mode. On systems where this setting is stored as the boolean string `true`, the numeric comparison fails and the startup script always regenerates the Light theme, even though Dark Mode is selected.

`gtk-theme-switcher.sh` already supports both numeric (`1`/`0`) and boolean (`true`/`false`) values, so startup behavior is inconsistent.

This change updates `ml4w-wallpaper` to recognize both representations, ensuring startup behavior matches the theme switcher and preserving the selected theme across logins.

## Testing

Tested on:

- Arch Linux
- Hyprland 0.55.4

Verified that:

- Dark mode persists after reboot.
- `ml4w-wallpaper` now runs Matugen in dark mode when GTK stores `gtk-application-prefer-dark-theme=true`.
- Existing numeric values (`1`) continue to work.