### PR TITLE
fix: use Lua dispatch syntax in scripts that call hyprctl dispatch

### DIFF
--- a/dotfiles/.config/hypr/scripts/moveTo.sh
+++ b/dotfiles/.config/hypr/scripts/moveTo.sh
@@ -36,12 +36,12 @@ window_addresses=$(hyprctl clients -j | jq -r ".[] | select(.workspace.id == $cu
 # Move each window to the target workspace
 for address in $window_addresses; do
     log_message "Moving window $address to workspace $target_workspace"
-    hyprctl dispatch movetoworkspacesilent "$target_workspace,address:$address"
+    hyprctl dispatch "hl.dsp.window.move({ workspace = \"$target_workspace\", silent = true, window = \"address:$address\" })"
 done
 
 log_message "Finished moving windows"
 
 # Switch to the target workspace
-hyprctl dispatch workspace "$target_workspace"
+hyprctl dispatch "hl.dsp.focus({ workspace = \"$target_workspace\" })"
 
 log_message "Switched to workspace $target_workspace"

--- a/dotfiles/.config/hypr/scripts/power.sh
+++ b/dotfiles/.config/hypr/scripts/power.sh
@@ -41,7 +41,7 @@ if [[ "$1" == "exit" ]]; then
 	echo ":: Exit"
 	terminate_clients
 	sleep 0.5
-	hyprctl dispatch exit
+	hyprctl dispatch "hl.dsp.exit()"
 	sleep 2
 fi
 

--- a/dotfiles/.config/ml4w/scripts/ml4w-toggle-allfloat
+++ b/dotfiles/.config/ml4w/scripts/ml4w-toggle-allfloat
@@ -4,5 +4,5 @@ mapfile -t addresses < <(
     hyprctl clients -j | jq -r --argjson ws "$ws_id" '.[] | select(.workspace.id == $ws) | .address'
 )
 for addr in "${addresses[@]}"; do
-    hyprctl dispatch togglefloating "address:$addr"
+    hyprctl dispatch "hl.dsp.window.float({ action = \"toggle\", window = \"address:$addr\" })"
 done

--- a/dotfiles/.config/wlogout/README.txt
+++ b/dotfiles/.config/wlogout/README.txt
@@ -1,7 +1,7 @@
 Select Logout Command depending on your setup:
 
 Use for Display Manager e.g., sddm (DEFAULT)
-sleep 1; hyprctl dispatch exit
+sleep 1; hyprctl dispatch "hl.dsp.exit()"
 
 Use for Arch Linux text based login
 sleep 1; loginctl terminate-user $USER


### PR DESCRIPTION
Since the dotfiles ship a Lua hypr config (`hyprland.lua`), Hyprland >= 0.54 parses the payload of an IPC `dispatch` request **as Lua**, wrapping it as `return hl.dispatch(<payload>)`. The legacy dispatcher grammar is then a syntax error, so the affected scripts are silent no-ops:

```
$ hyprctl dispatch workspace 3
error: [string "return hl.dispatch(workspace 3)"]:1: ')' expected near '3'

 → Note: dispatch in lua is a shorthand for hl.dispatch(...), your syntax might need to be updated.
```

### Verified broken on Hyprland 0.56.1 (Fedora 44, aarch64)

| File | Symptom |
|---|---|
| `.config/ml4w/scripts/ml4w-toggle-allfloat` | `SUPER + SHIFT + T` did nothing |
| `.config/hypr/scripts/moveTo.sh` | moved no windows, switched no workspace |
| `.config/hypr/scripts/power.sh` | never exited the session on `exit` |
| `.config/wlogout/README.txt` | documented the non-working command |

### Notes

Every replacement dispatcher and table field was checked against a live Hyprland 0.56.1 socket rather than taken from docs. Two things worth flagging for reviewers:

- **Unknown table fields are silently ignored and fall through to the *active* window**, so a wrong field name looks like it works. The window selector field is `window`, e.g. `hl.dsp.window.float({ action = "toggle", window = "address:0x..." })`. `target`, `address` and `win` all silently retarget the focused window.
- `.config/hypr/scripts/toggleallfloat.sh` is **left unchanged** — `workspaceopt` has no equivalent in the Lua dispatcher API (enumerated `hl.dsp` at runtime; there is no `workspaceopt`/`allfloat` entry).

### Compatibility

This makes the scripts require a Lua-config Hyprland, matching the `.lua` configs already shipped in `.config/hypr/`. If these dotfiles still need to support a legacy `hyprland.conf` setup, say so and I will gate each call on the config style instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)