### PR TITLE
fix: make ml4w-toggle-theme handle the boolean GTK theme preference

### DIFF
--- a/dotfiles/.config/ml4w/scripts/ml4w-toggle-theme
+++ b/dotfiles/.config/ml4w/scripts/ml4w-toggle-theme
@@ -3,6 +3,7 @@
 
 GTK3_SETTINGS_FILE="$HOME/.config/gtk-3.0/settings.ini"
 GTK4_SETTINGS_FILE="$HOME/.config/gtk-4.0/settings.ini"
+KEY="gtk-application-prefer-dark-theme"
 
 # Check if GTK3 settings file exists
 if [ ! -f "$GTK3_SETTINGS_FILE" ]; then
@@ -10,19 +11,31 @@ if [ ! -f "$GTK3_SETTINGS_FILE" ]; then
     exit 1
 fi
 
-# Toggle theme based on current setting in GTK3 file
-if grep -q "gtk-application-prefer-dark-theme=1" "$GTK3_SETTINGS_FILE"; then
-    # Switch to light theme
-    sed -i 's/gtk-application-prefer-dark-theme=1/gtk-application-prefer-dark-theme=0/' "$GTK3_SETTINGS_FILE"
-    if [ -f "$GTK4_SETTINGS_FILE" ]; then
-        sed -i 's/gtk-application-prefer-dark-theme=true/gtk-application-prefer-dark-theme=false/' "$GTK4_SETTINGS_FILE"
-    fi
-    echo "Switched to light theme."
-else
-    # Switch to dark theme
-    sed -i 's/gtk-application-prefer-dark-theme=0/gtk-application-prefer-dark-theme=1/' "$GTK3_SETTINGS_FILE"
-    if [ -f "$GTK4_SETTINGS_FILE" ]; then
-        sed -i 's/gtk-application-prefer-dark-theme=false/gtk-application-prefer-dark-theme=true/' "$GTK4_SETTINGS_FILE"
-    fi
-    echo "Switched to dark theme."
+# Read the current preference. It is a GTK boolean, so it can legitimately be
+# stored as 1/0 or as true/false: third-party GTK settings tools write the
+# boolean spelling. Accept both, like gtk-theme-switcher.sh already does.
+current=$(grep -E "^$KEY=" "$GTK3_SETTINGS_FILE" | awk -F'=' '{print $2}')
+
+case "$current" in
+    1 | true)
+        # Currently dark -> switch to light
+        gtk3_value=0
+        gtk4_value=false
+        message="Switched to light theme."
+        ;;
+    *)
+        # Currently light, unset or unrecognised -> switch to dark
+        gtk3_value=1
+        gtk4_value=true
+        message="Switched to dark theme."
+        ;;
+esac
+
+# Assign the new value instead of rewriting one specific spelling, so the
+# toggle works regardless of how the current value happens to be written.
+sed -i "s/^$KEY=.*/$KEY=$gtk3_value/" "$GTK3_SETTINGS_FILE"
+if [ -f "$GTK4_SETTINGS_FILE" ]; then
+    sed -i "s/^$KEY=.*/$KEY=$gtk4_value/" "$GTK4_SETTINGS_FILE"
 fi
+
+echo "$message"


### PR DESCRIPTION
### Description

This pull request fixes `ml4w-toggle-theme` so that it recognises the boolean spelling (`true`/`false`) of `gtk-application-prefer-dark-theme`, not only the numeric one (`1`/`0`).

### Changes
- [x] Improved <!-- Optimized existing functionality -->
- [x] Bug Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

`gtk-application-prefer-dark-theme` is a GTK **boolean**, so `true`/`false` is an equally valid spelling of `1`/`0`. The dotfiles ship `=1`, but third-party GTK settings tools normalise `settings.ini` to the boolean form — on my machine `kde-gtk-config`, which is part of the default CachyOS package set even in a Hyprland session.

Once the file holds `true`, the toggle stops working:

```bash
if grep -q "gtk-application-prefer-dark-theme=1" "$GTK3_SETTINGS_FILE"; then
```

That `grep` does not match `true`, so the script takes the `else` branch and runs `sed 's/...=0/...=1/'`, which does not match either. It prints `Switched to dark theme` while leaving the GTK3 file **unchanged**, so the user cannot switch modes from the UI at all — and there is no error to explain why.

There is a second, smaller problem in the same branch. Starting from `false`/`false`, the old code left GTK3 at `false` while setting GTK4 to `true`, so the two files ended up disagreeing about the mode.

This is the same class of bug as #1759 (which fixes the numeric comparison in `ml4w-wallpaper`), in a different script. The two changes are independent and touch different files, so they do not conflict. Together they cover both consumers that were still numeric-only: with only #1759 merged, the palette regenerates correctly but the user still cannot toggle back out of the state.

`gtk-theme-switcher.sh` already accepts both spellings ([line 49](https://github.com/mylinuxforwork/dotfiles/blob/3de368eb047c663d4ac06da1ce2558c96bc1ad2a/dotfiles/.config/ml4w/listeners/gtk-theme-switcher.sh#L49)), so this brings the toggle in line with the existing convention in the repo rather than introducing a new one.

**Approach:** read the value once, accept both spellings, then *assign* the new value instead of rewriting one specific spelling. That way the toggle works regardless of how the current value happens to be written, and it normalises the file as a side effect. GTK3 keeps the numeric form and GTK4 the boolean one, exactly as before.

### How Has This Been Tested?

- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

Tested on CachyOS (Arch-based), ML4W OS 2.12.3, Hyprland 0.56.1.

I ran both the original and the patched script against a throwaway `$HOME` for every combination of starting values, checking the resulting GTK3/GTK4 files rather than just the printed message:

**Before**

| gtk3 | gtk4 | output | result |
|---|---|---|---|
| `1` | `true` | Switched to light theme. | `0` / `false` ✅ |
| `0` | `false` | Switched to dark theme. | `1` / `true` ✅ |
| `true` | `true` | Switched to dark theme. | `true` / `true` ❌ **no change** |
| `false` | `false` | Switched to dark theme. | `false` / `true` ❌ **files disagree** |

**After**

| gtk3 | gtk4 | output | result |
|---|---|---|---|
| `1` | `true` | Switched to light theme. | `0` / `false` ✅ |
| `0` | `false` | Switched to dark theme. | `1` / `true` ✅ |
| `true` | `true` | Switched to light theme. | `0` / `false` ✅ |
| `false` | `false` | Switched to dark theme. | `1` / `true` ✅ |

My own `settings.ini` currently holds `true`, which is what led me to this, and running the unpatched script against it reproduces the no-op exactly as in the table. I tested the script directly rather than through its entry points, since both of them — the `SUPER + SHIFT + M` keybinding in `conf/keybindings/default.lua` and the Sidebar app — just invoke this script.

### Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes.

<!-- The repository has no test suite or CI workflows, so the three unchecked boxes are not
applicable. The testing I did is written out in full in the section above so it can be
reproduced. -->

### Screenshots

Not applicable — the change has no visual output of its own.

### Related Issues

Refs #1765

Related: #1759 (same class of bug in `ml4w-wallpaper`; independent change, different file)

### Additional Notes

Deliberately left out of scope, to keep the diff small and reviewable:

- **The key being absent entirely.** If `gtk-application-prefer-dark-theme` is missing from `settings.ini`, the script reports a switch to dark but writes nothing, because the `sed` has nothing to match. This behaviour is unchanged from before — the original had the same gap — so it is not a regression. Happy to add the key when missing if you would prefer that.
- **Anything that stops third-party tools from rewriting `settings.ini`.** That is outside what these dotfiles can control; this change just makes the script tolerant of both spellings.

Happy to adjust the style or split this differently if you prefer.
