### PR TITLE
Include checking for firmware updates in `ml4w-install-system-updates` using `fwupd`

### DIFF
--- a/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
+++ b/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
@@ -8,27 +8,27 @@
 
 # Check if command exists
 _checkCommandExists() {
-    command -v "$1" &> /dev/null
+  command -v "$1" &>/dev/null
 }
 
 _isInstalled() {
-    package="$1"
-    case $install_platform in
-        arch)
-            check="$($aur_helper -Qs --color always "${package}" | grep "local" | grep "${package} ")"
-            ;;
-        fedora)
-            check="$(dnf repoquery --quiet --installed ""${package}*"")"
-            ;;
-        *) ;;
-    esac
+  package="$1"
+  case $install_platform in
+  arch)
+    check="$($aur_helper -Qs --color always "${package}" | grep "local" | grep "${package} ")"
+    ;;
+  fedora)
+    check="$(dnf repoquery --quiet --installed ""${package}*"")"
+    ;;
+  *) ;;
+  esac
 
-    if [ -n "${check}" ]; then
-        echo 0 #'0' means 'true' in Bash
-        return #true
-    fi
-    echo 1 #'1' means 'false' in Bash
-    return #false
+  if [ -n "${check}" ]; then
+    echo 0 #'0' means 'true' in Bash
+    return #true
+  fi
+  echo 1 #'1' means 'false' in Bash
+  return #false
 }
 
 # ------------------------------------------------------
@@ -43,52 +43,74 @@ primarycolor=$(cat ~/.config/ml4w/colors/primary)
 onsurfacecolor=$(cat ~/.config/ml4w/colors/onsurface)
 onprimarycolor=$(cat ~/.config/ml4w/colors/onprimary)
 if gum confirm --selected.background=$primarycolor --selected.foreground=$onprimarycolor --prompt.foreground=$onsurfacecolor "DO YOU WANT TO START THE UPDATE NOW?"; then
-    echo
-    echo ":: Update started..."
+  echo
+  echo ":: Update started..."
 elif [ $? -eq 130 ]; then
-    exit 130
+  exit 130
 else
-    echo
-    echo ":: Update canceled."
-    exit
+  echo
+  echo ":: Update canceled."
+  exit
 fi
 
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 # Install update
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 
 # Arch
 if _checkCommandExists "pacman"; then
 
-    yay_installed="false"
-    paru_installed="false"
-    if _checkCommandExists "yay"; then
-        yay_installed="true"
-    fi
-    if _checkCommandExists "paru"; then
-        paru_installed="true"
-    fi
-    if [[ $yay_installed == "true" ]] && [[ $paru_installed == "false" ]]; then
-        yay
-    elif [[ $yay_installed == "false" ]] && [[ $paru_installed == "true" ]]; then
-        paru -Syu --noconfirm
-    else
-        sudo pacman -Syu --noconfirm
-    fi
+  yay_installed="false"
+  paru_installed="false"
+  if _checkCommandExists "yay"; then
+    yay_installed="true"
+  fi
+  if _checkCommandExists "paru"; then
+    paru_installed="true"
+  fi
+  if [[ $yay_installed == "true" ]] && [[ $paru_installed == "false" ]]; then
+    yay
+  elif [[ $yay_installed == "false" ]] && [[ $paru_installed == "true" ]]; then
+    paru -Syu --noconfirm
+  else
+    sudo pacman -Syu --noconfirm
+  fi
 
 # Fedora
 elif _checkCommandExists "dnf"; then
-    sudo dnf upgrade
+  sudo dnf upgrade
 else
-    echo ":: ERROR - Platform not supported"
-    echo "Press [ENTER] to close."
-    read
+  echo ":: ERROR - Platform not supported"
+  echo "Press [ENTER] to close."
+  read
 fi
 echo
 
 # Flatpak
 echo ":: Searching for Flatpak updates..."
 flatpak update
+echo
+
+# fwupd Firmware
+echo ":: Searching for Firmware updates..."
+fwupdmgr refresh
+updates=$(fwupdmgr get-updates 2>&1)
+echo "$updates"
+if ! echo "$updates" | grep -q "No updates available"; then
+  echo "Firmware updates available!"
+  echo
+  read -p "Do you want to install the available updates? Some updates may require a restart. (y/N) " -r choice
+
+  case "$choice" in
+  [yY] | [yY][eE][sS])
+    echo ":: Applying firmware updates..."
+    fwupdmgr update
+    ;;
+  *)
+    echo "Skipping updates. Updates can be run manually with 'fwupdmgr update'"
+    ;;
+  esac
+fi
 echo
 
 # Reload Waybar

--- a/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
+++ b/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
@@ -8,24 +8,24 @@
 
 # Check if command exists
 _checkCommandExists() {
-    command -v "$1" &>/dev/null
+    command -v "$1" &> /dev/null
 }
 
 _isInstalled() {
     package="$1"
     case $install_platform in
-    arch)
-      check="$($aur_helper -Qs --color always "${package}" | grep "local" | grep "${package} ")"
-      ;;
-    fedora)
-      check="$(dnf repoquery --quiet --installed ""${package}*"")"
-      ;;
-    *) ;;
+    	arch)
+      		check="$($aur_helper -Qs --color always "${package}" | grep "local" | grep "${package} ")"
+      	;;
+    	fedora)
+      		check="$(dnf repoquery --quiet --installed ""${package}*"")"
+      	;;
+    	*) ;;
     esac
 
     if [ -n "${check}" ]; then
-      echo 0 #'0' means 'true' in Bash
-      return #true
+      	echo 0 #'0' means 'true' in Bash
+      	return #true
     fi
     echo 1 #'1' means 'false' in Bash
     return #false
@@ -63,17 +63,17 @@ if _checkCommandExists "pacman"; then
     yay_installed="false"
     paru_installed="false"
     if _checkCommandExists "yay"; then
-      yay_installed="true"
+      	yay_installed="true"
     fi
     if _checkCommandExists "paru"; then
-      paru_installed="true"
+      	paru_installed="true"
     fi
     if [[ $yay_installed == "true" ]] && [[ $paru_installed == "false" ]]; then
-      yay
+      	yay
     elif [[ $yay_installed == "false" ]] && [[ $paru_installed == "true" ]]; then
-      paru -Syu --noconfirm
+      	paru -Syu --noconfirm
     else
-      sudo pacman -Syu --noconfirm
+      	sudo pacman -Syu --noconfirm
     fi
 
 # Fedora

--- a/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
+++ b/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
@@ -110,6 +110,9 @@ if ! echo "$updates" | grep -q "No updates available"; then
     echo "Skipping updates. Updates can be run manually with 'fwupdmgr update'"
     ;;
   esac
+elif echo "$updates" | grep -e "WARNING" -e "error" -e "No such file or directory" -e "Blocked executable" -e "failed to write-firmware"; then
+  echo "==> An error has occured and firmware updates could not be installed correctly."
+  echo "      Please check the console log for relevant errors."
 fi
 echo
 

--- a/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
+++ b/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
@@ -92,28 +92,30 @@ flatpak update
 echo
 
 # fwupd Firmware
-echo ":: Searching for Firmware updates..."
+echo ":: Searching for firmware updates..."
 fwupdmgr refresh
+
 updates=$(fwupdmgr get-updates 2>&1)
 echo "$updates"
-if ! echo "$updates" | grep -q "No updates available"; then
-    echo "Firmware updates available!"
-    echo
-    read -p "Do you want to install the available updates? Some updates may require a restart. (y/N) " -r choice
+# First check for common error patterns
+if echo "$updates" | grep --silent -e "WARNING:" -e "error" -e "No such file or directory" -e "Blocked executable" -e "failed to write-firmware"; then
+	echo 
+    echo "==> An error has occured and firmware updates could not be grabbed correctly. Please check the console log for relevant errors."
+    echo "Use the fwupd github page (https://github.com/fwupd/fwupd/wiki) to check for solutions to this error, or report any issues."
+elif ! echo "$updates" | grep -q "No updates available"; then
+	echo "==>Firmware updates available!"
+	echo
+	read -p "Do you want to install the available firmware updates? Some updates may require a restart. (y/N) " -r choice
 
-    case "$choice" in
-    [yY] | [yY][eE][sS])
-      echo ":: Applying firmware updates..."
-      fwupdmgr update
-      ;;
-    *)
-      echo "Skipping updates. Updates can be run manually with 'fwupdmgr update'"
-      ;;
-    esac
-elif echo "$updates" | grep --silent -e "WARNING" -e "error" -e "No such file or directory" -e "Blocked executable" -e "failed to write-firmware"; then
-    echo "==> An error has occured and firmware updates could not be installed correctly."
-    echo "      Please check the console log for relevant errors."
-    echo "Please use the fwupd github page (https://github.com/fwupd/fwupd/wiki) to check for solutions to this error, or report any issues."
+	case "$choice" in
+	    [yY] | [yY][eE][sS])
+		    echo ":: Applying firmware updates..."
+		    fwupdmgr update
+		    ;;
+	    *)
+		    echo "Skipping updates. Updates can be run manually with 'fwupdmgr update'"
+		    ;;
+	esac
 fi
 echo
 

--- a/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
+++ b/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
@@ -8,27 +8,27 @@
 
 # Check if command exists
 _checkCommandExists() {
-  command -v "$1" &>/dev/null
+    command -v "$1" &>/dev/null
 }
 
 _isInstalled() {
-  package="$1"
-  case $install_platform in
-  arch)
-    check="$($aur_helper -Qs --color always "${package}" | grep "local" | grep "${package} ")"
-    ;;
-  fedora)
-    check="$(dnf repoquery --quiet --installed ""${package}*"")"
-    ;;
-  *) ;;
-  esac
+    package="$1"
+    case $install_platform in
+    arch)
+      check="$($aur_helper -Qs --color always "${package}" | grep "local" | grep "${package} ")"
+      ;;
+    fedora)
+      check="$(dnf repoquery --quiet --installed ""${package}*"")"
+      ;;
+    *) ;;
+    esac
 
-  if [ -n "${check}" ]; then
-    echo 0 #'0' means 'true' in Bash
-    return #true
-  fi
-  echo 1 #'1' means 'false' in Bash
-  return #false
+    if [ -n "${check}" ]; then
+      echo 0 #'0' means 'true' in Bash
+      return #true
+    fi
+    echo 1 #'1' means 'false' in Bash
+    return #false
 }
 
 # ------------------------------------------------------
@@ -43,14 +43,14 @@ primarycolor=$(cat ~/.config/ml4w/colors/primary)
 onsurfacecolor=$(cat ~/.config/ml4w/colors/onsurface)
 onprimarycolor=$(cat ~/.config/ml4w/colors/onprimary)
 if gum confirm --selected.background=$primarycolor --selected.foreground=$onprimarycolor --prompt.foreground=$onsurfacecolor "DO YOU WANT TO START THE UPDATE NOW?"; then
-  echo
-  echo ":: Update started..."
+    echo
+    echo ":: Update started..."
 elif [ $? -eq 130 ]; then
-  exit 130
+    exit 130
 else
-  echo
-  echo ":: Update canceled."
-  exit
+    echo
+    echo ":: Update canceled."
+    exit
 fi
 
 # -----------------------------------------------------
@@ -60,29 +60,29 @@ fi
 # Arch
 if _checkCommandExists "pacman"; then
 
-  yay_installed="false"
-  paru_installed="false"
-  if _checkCommandExists "yay"; then
-    yay_installed="true"
-  fi
-  if _checkCommandExists "paru"; then
-    paru_installed="true"
-  fi
-  if [[ $yay_installed == "true" ]] && [[ $paru_installed == "false" ]]; then
-    yay
-  elif [[ $yay_installed == "false" ]] && [[ $paru_installed == "true" ]]; then
-    paru -Syu --noconfirm
-  else
-    sudo pacman -Syu --noconfirm
-  fi
+    yay_installed="false"
+    paru_installed="false"
+    if _checkCommandExists "yay"; then
+      yay_installed="true"
+    fi
+    if _checkCommandExists "paru"; then
+      paru_installed="true"
+    fi
+    if [[ $yay_installed == "true" ]] && [[ $paru_installed == "false" ]]; then
+      yay
+    elif [[ $yay_installed == "false" ]] && [[ $paru_installed == "true" ]]; then
+      paru -Syu --noconfirm
+    else
+      sudo pacman -Syu --noconfirm
+    fi
 
 # Fedora
 elif _checkCommandExists "dnf"; then
-  sudo dnf upgrade
+    sudo dnf upgrade
 else
-  echo ":: ERROR - Platform not supported"
-  echo "Press [ENTER] to close."
-  read
+    echo ":: ERROR - Platform not supported"
+    echo "Press [ENTER] to close."
+    read
 fi
 echo
 
@@ -97,23 +97,23 @@ fwupdmgr refresh
 updates=$(fwupdmgr get-updates 2>&1)
 echo "$updates"
 if ! echo "$updates" | grep -q "No updates available"; then
-  echo "Firmware updates available!"
-  echo
-  read -p "Do you want to install the available updates? Some updates may require a restart. (y/N) " -r choice
+    echo "Firmware updates available!"
+    echo
+    read -p "Do you want to install the available updates? Some updates may require a restart. (y/N) " -r choice
 
-  case "$choice" in
-  [yY] | [yY][eE][sS])
-    echo ":: Applying firmware updates..."
-    fwupdmgr update
-    ;;
-  *)
-    echo "Skipping updates. Updates can be run manually with 'fwupdmgr update'"
-    ;;
-  esac
-elif echo "$updates" | grep -e "WARNING" -e "error" -e "No such file or directory" -e "Blocked executable" -e "failed to write-firmware"; then
-  echo "==> An error has occured and firmware updates could not be installed correctly."
-  echo "      Please check the console log for relevant errors."
-  echo "Please use the fwupd github page (https://github.com/fwupd/fwupd/wiki) to check for solutions to this error, or report any issues."
+    case "$choice" in
+    [yY] | [yY][eE][sS])
+      echo ":: Applying firmware updates..."
+      fwupdmgr update
+      ;;
+    *)
+      echo "Skipping updates. Updates can be run manually with 'fwupdmgr update'"
+      ;;
+    esac
+elif echo "$updates" | grep --silent -e "WARNING" -e "error" -e "No such file or directory" -e "Blocked executable" -e "failed to write-firmware"; then
+    echo "==> An error has occured and firmware updates could not be installed correctly."
+    echo "      Please check the console log for relevant errors."
+    echo "Please use the fwupd github page (https://github.com/fwupd/fwupd/wiki) to check for solutions to this error, or report any issues."
 fi
 echo
 

--- a/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
+++ b/dotfiles/.config/ml4w/scripts/ml4w-install-system-updates
@@ -113,6 +113,7 @@ if ! echo "$updates" | grep -q "No updates available"; then
 elif echo "$updates" | grep -e "WARNING" -e "error" -e "No such file or directory" -e "Blocked executable" -e "failed to write-firmware"; then
   echo "==> An error has occured and firmware updates could not be installed correctly."
   echo "      Please check the console log for relevant errors."
+  echo "Please use the fwupd github page (https://github.com/fwupd/fwupd/wiki) to check for solutions to this error, or report any issues."
 fi
 echo
 

--- a/setup/dependencies/packages-arch
+++ b/setup/dependencies/packages-arch
@@ -30,3 +30,4 @@ quickshell
 awww
 matugen
 nwg-displays
+fwupd


### PR DESCRIPTION
### Description

<!-- Provide a concise description of the changes made in this pull request. -->
This pull request updates `dotifles/.config/ml4w/scripts/ml4w-install-system-updates` to check for firmware updates using fwupd automatically, and also gives the user the option to install automatically or manually. The fwupd package is installed by default on Fedora and openSUSE distros, so it is only added as a dependency on Arch.

### Changes
- [ ] Improved <!-- Optimized existing functionality -->
- [ ] Bug Fixes <!-- Fixes Scripts/Other -->
- [x] Feature <!-- Added -->
- [ ] Documentation <!-- Changes related to the documentation -->
- [ ] Other <!-- Refactoring, cleanup, or non-functional changes -->

### Context

<!-- Why is this change necessary? What problem does it solve or what new feature does it add? -->
By default, the only way most people have to check for firmware updates is manually via fwupdmgr get-updates, but I figure that this script already runs flatpak update alongside grabbing system package updates, so we may as well use this opportunity to check for firmware updates. I edited my ml4w-install-system-updates script on my pc to automatically check for firmware updates using fwupd, and checks the output to see if any updates are available, asking to install if true.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [ ] Tested on Fedora Linux/Based Distro.
- [ ] Tested on openSuse.

I have used these script changes for about 4 months on my personal ml4w install that I have modified to my liking. Other than some issues that I caused with my personal Arch installation, it has worked perfectly, and notified my of firmware updates and even installed them correctly. I test the if statements by flipping the true/false check, and they work well. You can try this as well to check. fwupd comes pre-installed and works on the other 2 advertised distros, so there shouldn't be any issues there.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes.

### Screenshots 

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->
<img width="989" height="848" alt="image" src="https://github.com/user-attachments/assets/1cb113d5-5753-4824-8625-9924d8dba428" />
NOTE: The "No target found." message is from quickshell. I haven't updated my ML4W installation in a while so it doesn't have the quickshell updates notifier. This should not appear on modern ML4W builds.

### Related Issues

<!-- If this PR fixes an issue, include the relevant issue number here (e.g., "Fixes #123") -->
Does not relate to any issues.

### Additional Notes

<!-- Add any other context, technical details, or considerations you'd like to share. -->
None I have found. If the user's installation is atypical (differing EFI boot location) this will fail, but that is the fault of fwupd, not necessarily this script. I have included a catch for these errors, and the script will tell the user if any of these errors are in the output. It also tells the user to refer to the documentation on fwupd instead of making an issue here about the error they receive.